### PR TITLE
Update paths to inflammation files for the lesson 06-cmdline.

### DIFF
--- a/06-cmdline.Rmd
+++ b/06-cmdline.Rmd
@@ -181,9 +181,11 @@ The * is a wildcard character in the Unix Shell.
 Thus all the files in the current working directory are included as arguments to  arith.R.
 ```
 
-  + Using the function `list.files` introduced in a previous [lesson](03-loops-R.html), write a command-line program that lists all the files in the current directory that contain a specific pattern:
+  + Using the function `list.files` introduced in a previous [lesson](03-loops-R.html), write a command-line program, `find-pattern.R`, that lists all the files in the current directory that contain a specific pattern:
 
 ```{r, engine='bash'}
+# For example, searching for the pattern "print-args" returns the two scripts we
+# wrote earlier
 Rscript find-pattern.R print-args
 ```
 

--- a/06-cmdline.Rmd
+++ b/06-cmdline.Rmd
@@ -14,7 +14,7 @@ In order to do that, we need to make our programs work like other Unix command-l
 For example, we may want a program that reads a data set and prints the average inflammation per patient:
 
 ~~~
-$ Rscript readings.R --mean inflammation-01.csv
+$ Rscript readings.R --mean data/inflammation-01.csv
 5.45
 5.425
 6.1
@@ -27,13 +27,13 @@ $ Rscript readings.R --mean inflammation-01.csv
 but we might also want to look at the minimum of the first four lines
 
 ~~~
-$ head -4 inflammation-01.csv | Rscript readings.R --min
+$ head -4 data/inflammation-01.csv | Rscript readings.R --min
 ~~~
 
 or the maximum inflammations in several files one after another:
 
 ~~~
-$ Rscript readings.R --max inflammation-*.csv
+$ Rscript readings.R --max data/inflammation-*.csv
 ~~~
 
 Our overall requirements are:
@@ -184,7 +184,7 @@ Thus all the files in the current working directory are included as arguments to
   + Using the function `list.files` introduced in a previous [lesson](03-loops-R.html), write a command-line program that lists all the files in the current directory that contain a specific pattern:
 
 ```{r, engine='bash'}
-Rscript find-pattern.R inflammation
+Rscript find-pattern.R print-args
 ```
 
 ```{r third-answer, include=FALSE, engine='bash'}
@@ -198,15 +198,15 @@ Since 60 lines of output per file is a lot to page through, we'll start by using
 Let's investigate them from the Unix Shell:
 
 ```{r, engine='bash'}
-ls small-*.csv
+ls data/small-*.csv
 ```
 
 ```{r, engine='bash'}
-cat small-01.csv
+cat data/small-01.csv
 ```
 
 ```{r, engine='bash'}
-Rscript readings-02.R small-01.csv
+Rscript readings-02.R data/small-01.csv
 ```
 
 Using small data files as input also allows us to check our results more easily: here, for example, we can see that our program is calculating the mean correctly for each line, whereas we were really taking it on faith before.
@@ -226,7 +226,7 @@ cat readings-03.R
 and here it is in action:
 
 ```{r, engine='bash'}
-Rscript readings-03.R small-01.csv small-02.csv
+Rscript readings-03.R data/small-01.csv data/small-02.csv
 ```
 
 **Note**: at this point, we have created three versions of our script called `readings-01.R`, `readings-02.R`, and `readings-03.R`.
@@ -245,10 +245,10 @@ cat check.R
 ```{r testing, include=FALSE, engine='bash'}
 # For testing that it works.
 # Should pass check:
-Rscript check.R small-0*
-Rscript check.R inflammation-*
+Rscript check.R data/small-0*
+Rscript check.R data/inflammation-*
 # Should fail check:
-Rscript check.R small-0* inflammation-*
+Rscript check.R data/small-0* data/inflammation-*
 ```
 
 ### Handling Command-Line Flags
@@ -263,7 +263,7 @@ cat readings-04.R
 And we can confirm this works by running it from the Unix Shell:
 
 ```{r engine='bash'}
-Rscript readings-04.R --max small-01.csv
+Rscript readings-04.R --max data/small-01.csv
 ```
 
 but there are several things wrong with it:
@@ -316,7 +316,7 @@ In this example, we passed it as an argument to the function `readLines`, which 
 Let's try running it from the Unix Shell as if it were a regular command-line program:
 
 ```{r engine='bash'}
-Rscript count-stdin.R < small-01.csv
+Rscript count-stdin.R < data/small-01.csv
 ```
 
 Note that because we did not specify `sep = "\n"` when calling `cat`, the output is written on the same line.
@@ -324,7 +324,7 @@ Note that because we did not specify `sep = "\n"` when calling `cat`, the output
 A common mistake is to try to run something that reads from standard input like this:
 
 ```{r eval=FALSE, engine='bash'}
-Rscript count-stdin.R small-01.csv
+Rscript count-stdin.R data/small-01.csv
 ```
 
 i.e., to forget the `<` character that redirect the file to standard input.
@@ -346,7 +346,7 @@ Let's try it out.
 Instead of calculating the mean inflammation of every patient, we'll only calculate the mean for the first 10 patients (rows):
 
 ```{r engine='bash'}
-head inflammation-01.csv | Rscript readings-06.R --mean
+head data/inflammation-01.csv | Rscript readings-06.R --mean
 ```
 
 And now we're done: the program now does everything we set out to do.

--- a/06-cmdline.html
+++ b/06-cmdline.html
@@ -275,9 +275,11 @@ main()
 
 <ul>
 <li><p>What goes wrong if you try to add multiplication using <code>*</code> to the program?</p></li>
-<li><p>Using the function <code>list.files</code> introduced in a previous <a href="03-loops-R.html">lesson</a>, write a command-line program that lists all the files in the current directory that contain a specific pattern:</p></li>
+<li><p>Using the function <code>list.files</code> introduced in a previous <a href="03-loops-R.html">lesson</a>, write a command-line program, <code>find-pattern.R</code>, that lists all the files in the current directory that contain a specific pattern:</p></li>
 </ul>
-<pre class='in'><code>Rscript find-pattern.R print-args</code></pre>
+<pre class='in'><code># For example, searching for the pattern "print-args" returns the two scripts we
+# wrote earlier
+Rscript find-pattern.R print-args</code></pre>
 
 
 

--- a/06-cmdline.html
+++ b/06-cmdline.html
@@ -29,7 +29,7 @@
           
 <h2 id="command-line-programs">Command-Line Programs</h2>
 <p>The R Console and other interactive tools like RStudio are great for prototyping code and exploring data, but sooner or later we will want to use our program in a pipeline or run it in a shell script to process thousands of data files. In order to do that, we need to make our programs work like other Unix command-line tools. For example, we may want a program that reads a data set and prints the average inflammation per patient:</p>
-<pre><code>$ Rscript readings.R --mean inflammation-01.csv
+<pre><code>$ Rscript readings.R --mean data/inflammation-01.csv
 5.45
 5.425
 6.1
@@ -38,9 +38,9 @@
 7.05
 5.9</code></pre>
 <p>but we might also want to look at the minimum of the first four lines</p>
-<pre><code>$ head -4 inflammation-01.csv | Rscript readings.R --min</code></pre>
+<pre><code>$ head -4 data/inflammation-01.csv | Rscript readings.R --min</code></pre>
 <p>or the maximum inflammations in several files one after another:</p>
-<pre><code>$ Rscript readings.R --max inflammation-*.csv</code></pre>
+<pre><code>$ Rscript readings.R --max data/inflammation-*.csv</code></pre>
 <p>Our overall requirements are:</p>
 <ol style="list-style-type: decimal">
 <li>If no filename is given on the command line, read data from <a href="../../gloss.html#standard-input">standard input</a>.</li>
@@ -58,15 +58,17 @@
 </div>
 <h3 id="command-line-arguments">Command-Line Arguments</h3>
 <p>Using the text editor of your choice, save the following line of code in a text file called <code>session-info.R</code>:</p>
-<div class="out">
-<pre class='out'><code>sessionInfo()
-</code></pre>
-</div>
+<div class='out'><pre class='out'><code>sessionInfo()
+</code></pre></div>
+
 <p>The function, <code>sessionInfo</code>, outputs the version of R you are running as well as the type of computer you are using (as well as the versions of the packages that have been loaded). This is very useful information to include when asking others for help with your R code.</p>
 <p>Now we can run the code in the file we created from the Unix Shell using <code>Rscript</code>:</p>
 <pre class='in'><code>Rscript session-info.R</code></pre>
-<div class="out">
-<pre class='out'><code>R version 3.1.1 (2014-07-10)
+
+
+
+
+<div class='out'><pre class='out'><code>R version 3.1.2 (2014-10-31)
 Platform: x86_64-pc-linux-gnu (64-bit)
 
 locale:
@@ -79,27 +81,28 @@ locale:
 
 attached base packages:
 [1] stats     graphics  grDevices utils     datasets  base     
-</code></pre>
-</div>
+</code></pre></div>
+
 <blockquote>
 <p><strong>Tip:</strong> If that did not work, remember that you must be in the correct directory. You can determine which directory you are currently in using <code>pwd</code> and change to a different directory using <code>cd</code>. For a review, see this <a href="../shell/01-filedir.html">lesson</a> or the <a href="../ref/01-shell.html">Unix Shell Reference</a>.</p>
 </blockquote>
 <p>Now let's create another script that does something more interesting. Write the following lines in a file named <code>print-args.R</code>:</p>
-<div class="out">
-<pre class='out'><code>args <- commandArgs()
+<div class='out'><pre class='out'><code>args <- commandArgs()
 cat(args, sep = "\n")
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>The function <code>commandArgs</code> extracts all the command line arguments and returns them as a vector. The function <code>cat</code>, similar to the <code>cat</code> of the Unix Shell, outputs the contents of the variable. Since we did not specify a filename for writing, <code>cat</code> sends the output to <a href="../../gloss.html#standard-output">standard output</a>, which we can then pipe to other Unix functions. Because we set the argument <code>sep</code> to <code>&quot;\n&quot;</code>, which is the symbol to start a new line, each element of the vector is printed on its own line. Let's see what happens when we run this program in the Unix Shell:</p>
 <pre class='in'><code>Rscript print-args.R</code></pre>
-<div class="out">
-<pre class='out'><code>/usr/lib/R/bin/exec/R
+
+
+
+
+<div class='out'><pre class='out'><code>/usr/lib/R/bin/exec/R
 --slave
 --no-restore
 --file=print-args.R
---args
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>From this output, we learn that <code>Rscript</code> is just a convenience command for running R scripts. The first argument in the vector is the path to the <code>R</code> executable. The following are all command-line arguments that affect the behavior of R. From the R help file:</p>
 <ul>
 <li><code>--slave</code>: Make R run as quietly as possible</li>
@@ -109,18 +112,24 @@ cat(args, sep = "\n")
 </ul>
 <p>Thus running a file with Rscript is an easier way to run the following:</p>
 <pre class='in'><code>R --slave --no-restore --file=print-args.R --args</code></pre>
-<div class="out">
-<pre class='out'><code>/usr/lib/R/bin/exec/R
+
+
+
+
+<div class='out'><pre class='out'><code>/usr/lib/R/bin/exec/R
 --slave
 --no-restore
 --file=print-args.R
 --args
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>If we run it with a few arguments, however:</p>
 <pre class='in'><code>Rscript print-args.R first second third</code></pre>
-<div class="out">
-<pre class='out'><code>/usr/lib/R/bin/exec/R
+
+
+
+
+<div class='out'><pre class='out'><code>/usr/lib/R/bin/exec/R
 --slave
 --no-restore
 --file=print-args.R
@@ -128,39 +137,41 @@ cat(args, sep = "\n")
 first
 second
 third
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>then <code>commandArgs</code> adds each of those arguments to the vector it returns. Since the first elements of the vector are always the same, we can tell <code>commandArgs</code> to only return the arguments that come after <code>--args</code>. Let's update <code>print-args.R</code> and save it as <code>print-args-trailing.R</code>:</p>
-<div class="out">
-<pre class='out'><code>args <- commandArgs(trailingOnly = TRUE)
+<div class='out'><pre class='out'><code>args <- commandArgs(trailingOnly = TRUE)
 cat(args, sep = "\n")
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>And then run <code>print-args-trailing</code> from the Unix Shell:</p>
 <pre class='in'><code>Rscript print-args-trailing.R first second third</code></pre>
-<div class="out">
-<pre class='out'><code>first
+
+
+
+
+<div class='out'><pre class='out'><code>first
 second
 third
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>Now <code>commandArgs</code> returns only the arguments that we listed after <code>print-args-trailing.R</code>.</p>
 <p>With this in hand, let's build a version of <code>readings.R</code> that always prints the per-patient (per-row) mean of a single data file. The first step is to write a function that outlines our implementation, and a placeholder for the function that does the actual work. By convention this function is usually called <code>main</code>, though we can call it whatever we want. Write the following code in a file called <code>readings-01.R</code>:</p>
-<div class="out">
-<pre class='out'><code>main <- function() {
+<div class='out'><pre class='out'><code>main <- function() {
   args <- commandArgs(trailingOnly = TRUE)
   filename <- args[1]
   dat <- read.csv(file = filename, header = FALSE)
   mean_per_patient <- apply(dat, 1, mean)
   cat(mean_per_patient, sep = "\n")
 }
-</code></pre>
-</div>
+</code></pre></div>
+
+
 <p>This function gets the name of the file to process from the first element returned by <code>commandArgs</code>. Here's a simple test to run from the Unix Shell:</p>
-<pre class='in'><code>Rscript readings-01.R inflammation-01.csv</code></pre>
+<pre class='in'><code>Rscript readings-01.R data/inflammation-01.csv</code></pre>
+
 <p>There is no output because we have defined a function, but haven't actually called it. Let's add a call to <code>main</code> and save it as <code>readings-02.R</code>:</p>
-<div class="out">
-<pre class='out'><code>main <- function() {
+<div class='out'><pre class='out'><code>main <- function() {
   args <- commandArgs(trailingOnly = TRUE)
   filename <- args[1]
   dat <- read.csv(file = filename, header = FALSE)
@@ -169,11 +180,15 @@ third
 }
 
 main()
-</code></pre>
-</div>
-<pre class='in'><code>Rscript readings-02.R inflammation-01.csv</code></pre>
-<div class="out">
-<pre class='out'><code>5.45
+</code></pre></div>
+
+
+<pre class='in'><code>Rscript readings-02.R data/inflammation-01.csv</code></pre>
+
+
+
+
+<div class='out'><pre class='out'><code>5.45
 5.425
 6.1
 5.9
@@ -233,80 +248,82 @@ main()
 6.4
 7.05
 5.9
-</code></pre>
-</div>
+</code></pre></div>
+
 <h4 id="challenges">Challenges</h4>
 <ul>
 <li>Write a command-line program that does addition and subtraction. <strong>Hint:</strong> Everything argument read from the command-line is interpreted as a character <a href="../../gloss.html#string">string</a>. You can convert from a string to a number using the function <code>as.numeric</code>.</li>
 </ul>
 <pre class='in'><code>Rscript arith.R 1 + 2</code></pre>
-<div class="out">
-<pre class='out'><code>3
-</code></pre>
-</div>
+
+
+
+
+<div class='out'><pre class='out'><code>3
+</code></pre></div>
+
+
 <pre class='in'><code>Rscript arith.R 3 - 4</code></pre>
-<div class="out">
-<pre class='out'><code>-1
-</code></pre>
-</div>
+
+
+
+
+<div class='out'><pre class='out'><code>-1
+</code></pre></div>
+
+
+
 <ul>
 <li><p>What goes wrong if you try to add multiplication using <code>*</code> to the program?</p></li>
 <li><p>Using the function <code>list.files</code> introduced in a previous <a href="03-loops-R.html">lesson</a>, write a command-line program that lists all the files in the current directory that contain a specific pattern:</p></li>
 </ul>
-<pre class='in'><code>Rscript find-pattern.R inflammation</code></pre>
-<div class="out">
-<pre class='out'><code>inflammation-01.csv
-inflammation-01.pdf
-inflammation-02.csv
-inflammation-02.pdf
-inflammation-03.csv
-inflammation-03.pdf
-inflammation-04.csv
-inflammation-04.pdf
-inflammation-05.csv
-inflammation-05.pdf
-inflammation-06.csv
-inflammation-06.pdf
-inflammation-07.csv
-inflammation-07.pdf
-inflammation-08.csv
-inflammation-08.pdf
-inflammation-09.csv
-inflammation-09.pdf
-inflammation-10.csv
-inflammation-10.pdf
-inflammation-11.csv
-inflammation-11.pdf
-inflammation-12.csv
-inflammation-12.pdf
-</code></pre>
-</div>
+<pre class='in'><code>Rscript find-pattern.R print-args</code></pre>
+
+
+
+
+<div class='out'><pre class='out'><code>print-args.R
+print-args-trailing.R
+</code></pre></div>
+
+
+
 <h3 id="handling-multiple-files">Handling Multiple Files</h3>
 <p>The next step is to teach our program how to handle multiple files. Since 60 lines of output per file is a lot to page through, we'll start by using three smaller files, each of which has three days of data for two patients. Let's investigate them from the Unix Shell:</p>
-<pre class='in'><code>ls small-*.csv</code></pre>
-<div class="out">
-<pre class='out'><code>small-01.csv
-small-02.csv
-small-03.csv
-</code></pre>
-</div>
-<pre class='in'><code>cat small-01.csv</code></pre>
-<div class="out">
-<pre class='out'><code>0,0,1
+<pre class='in'><code>ls data/small-*.csv</code></pre>
+
+
+
+
+<div class='out'><pre class='out'><code>data/small-01.csv
+data/small-02.csv
+data/small-03.csv
+</code></pre></div>
+
+
+<pre class='in'><code>cat data/small-01.csv</code></pre>
+
+
+
+
+<div class='out'><pre class='out'><code>0,0,1
 0,1,2
-</code></pre>
-</div>
-<pre class='in'><code>Rscript readings-02.R small-01.csv</code></pre>
-<div class="out">
-<pre class='out'><code>0.3333333
+</code></pre></div>
+
+
+<pre class='in'><code>Rscript readings-02.R data/small-01.csv</code></pre>
+
+
+
+
+<div class='out'><pre class='out'><code>0.3333333
 1
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>Using small data files as input also allows us to check our results more easily: here, for example, we can see that our program is calculating the mean correctly for each line, whereas we were really taking it on faith before. This is yet another rule of programming: &quot;<a href="../../rules.html#test-simple-first">test the simple things first</a>&quot;.</p>
 <p>We want our program to process each file separately, so we need a loop that executes once for each filename. If we specify the files on the command line, the filenames will be returned by <code>commandArgs(trailingOnly = TRUE)</code>. We'll need to handle an unknown number of filenames, since our program could be run for any number of files.</p>
 <p>The solution is to loop over the vector returned by <code>commandArgs(trailingOnly = TRUE)</code>. Here's our changed program, which we'll save as <code>readings-03.R</code>:</p>
-<div class="out">
-<pre class='out'><code>main <- function() {
+<div class='out'><pre class='out'><code>main <- function() {
   args <- commandArgs(trailingOnly = TRUE)
   for (filename in args) {
     dat <- read.csv(file = filename, header = FALSE)
@@ -316,17 +333,20 @@ small-03.csv
 }
 
 main()
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>and here it is in action:</p>
-<pre class='in'><code>Rscript readings-03.R small-01.csv small-02.csv</code></pre>
-<div class="out">
-<pre class='out'><code>0.3333333
+<pre class='in'><code>Rscript readings-03.R data/small-01.csv data/small-02.csv</code></pre>
+
+
+
+
+<div class='out'><pre class='out'><code>0.3333333
 1
 13.66667
 11
-</code></pre>
-</div>
+</code></pre></div>
+
 <p><strong>Note</strong>: at this point, we have created three versions of our script called <code>readings-01.R</code>, <code>readings-02.R</code>, and <code>readings-03.R</code>. We wouldn't do this in real life: instead, we would have one file called <code>readings.R</code> that we committed to version control every time we got an enhancement working. For teaching, though, we need all the successive versions side by side.</p>
 <h4 id="challenges-1">Challenges</h4>
 <ul>
@@ -334,8 +354,7 @@ main()
 </ul>
 <h3 id="handling-command-line-flags">Handling Command-Line Flags</h3>
 <p>The next step is to teach our program to pay attention to the <code>--min</code>, <code>--mean</code>, and <code>--max</code> flags. These always appear before the names of the files, so let's save the following in <code>readings-04.R</code>:</p>
-<div class="out">
-<pre class='out'><code>main <- function() {
+<div class='out'><pre class='out'><code>main <- function() {
   args <- commandArgs(trailingOnly = TRUE)
   action <- args[1]
   filenames <- args[-1]
@@ -355,23 +374,25 @@ main()
 }
 
 main()
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>And we can confirm this works by running it from the Unix Shell:</p>
-<pre class='in'><code>Rscript readings-04.R --max small-01.csv</code></pre>
-<div class="out">
-<pre class='out'><code>1
+<pre class='in'><code>Rscript readings-04.R --max data/small-01.csv</code></pre>
+
+
+
+
+<div class='out'><pre class='out'><code>1
 2
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>but there are several things wrong with it:</p>
 <ol style="list-style-type: decimal">
 <li><p><code>main</code> is too large to read comfortably.</p></li>
 <li><p>If <code>action</code> isn't one of the three recognized flags, the program loads each file but does nothing with it (because none of the branches in the conditional match). <a href="../../gloss.html#silent-failure">Silent failures</a> like this are always hard to debug.</p></li>
 </ol>
 <p>This version pulls the processing of each file out of the loop into a function of its own. It also checks that <code>action</code> is one of the allowed flags before doing any processing, so that the program fails fast. We'll save it as <code>readings-05.R</code>:</p>
-<div class="out">
-<pre class='out'><code>main <- function() {
+<div class='out'><pre class='out'><code>main <- function() {
   args <- commandArgs(trailingOnly = TRUE)
   action <- args[1]
   filenames <- args[-1]
@@ -396,8 +417,8 @@ process <- function(filename, action) {
 }
 
 main()
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>This is four lines longer than its predecessor, but broken into more digestible chunks of 8 and 12 lines.</p>
 <blockquote>
 <p><strong>Tip:</strong> R has a package named <a href="http://cran.r-project.org/web/packages/argparse/index.html">argparse</a> that helps handle complex command-line flags (it utilizes a <a href="http://docs.python.org/dev/library/argparse.html">Python module</a> of the same name). We will not cover this package in this lesson but when you start writing programs with multiple parameters you'll want to read through the package's <a href="http://cran.r-project.org/web/packages/argparse/vignettes/argparse.pdf">vignette</a>.</p>
@@ -409,26 +430,28 @@ main()
 </ul>
 <h3 id="handling-standard-input">Handling Standard Input</h3>
 <p>The next thing our program has to do is read data from standard input if no filenames are given so that we can put it in a pipeline, redirect input to it, and so on. Let's experiment in another script, which we'll save as <code>count-stdin.R</code>:</p>
-<div class="out">
-<pre class='out'><code>lines <- readLines(con = file("stdin"))
+<div class='out'><pre class='out'><code>lines <- readLines(con = file("stdin"))
 count <- length(lines)
 cat("lines in standard input: ")
 cat(count, sep = "\n")
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>This little program reads lines from the program's standard input using <code>file(&quot;stdin&quot;)</code>. This allows us to do almost anything with it that we could do to a regular file. In this example, we passed it as an argument to the function <code>readLines</code>, which stores each line as an element in a vector. Let's try running it from the Unix Shell as if it were a regular command-line program:</p>
-<pre class='in'><code>Rscript count-stdin.R < small-01.csv</code></pre>
-<div class="out">
-<pre class='out'><code>lines in standard input: 2
-</code></pre>
-</div>
+<pre class='in'><code>Rscript count-stdin.R < data/small-01.csv</code></pre>
+
+
+
+
+<div class='out'><pre class='out'><code>lines in standard input: 2
+</code></pre></div>
+
 <p>Note that because we did not specify <code>sep = &quot;\n&quot;</code> when calling <code>cat</code>, the output is written on the same line.</p>
 <p>A common mistake is to try to run something that reads from standard input like this:</p>
-<pre class='in'><code>Rscript count-stdin.R small-01.csv</code></pre>
+<pre class='in'><code>Rscript count-stdin.R data/small-01.csv</code></pre>
+
 <p>i.e., to forget the <code>&lt;</code> character that redirect the file to standard input. In this case, there's nothing in standard input, so the program waits at the start of the loop for someone to type something on the keyboard. We can type some input, but R keeps running because it doesn't know when the standard input has ended. If you ran this, you can pause R by typing <code>ctrl</code>+<code>z</code> (technically it is still paused in the background; if you want to fully kill the process follow these <a href="http://linux.about.com/library/cmd/blcmdl_kill.htm">instructions</a>).</p>
 <p>We now need to rewrite the program so that it loads data from <code>file(&quot;stdin&quot;)</code> if no filenames are provided. Luckily, <code>read.csv</code> can handle either a filename or an open file as its first parameter, so we don't actually need to change <code>process</code>. That leaves <code>main</code>, which we'll update and save as <code>readings-06.R</code>:</p>
-<div class="out">
-<pre class='out'><code>main <- function() {
+<div class='out'><pre class='out'><code>main <- function() {
   args <- commandArgs(trailingOnly = TRUE)
   action <- args[1]
   filenames <- args[-1]
@@ -457,12 +480,15 @@ process <- function(filename, action) {
 }
 
 main()
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>Let's try it out. Instead of calculating the mean inflammation of every patient, we'll only calculate the mean for the first 10 patients (rows):</p>
-<pre class='in'><code>head inflammation-01.csv | Rscript readings-06.R --mean</code></pre>
-<div class="out">
-<pre class='out'><code>5.45
+<pre class='in'><code>head data/inflammation-01.csv | Rscript readings-06.R --mean</code></pre>
+
+
+
+
+<div class='out'><pre class='out'><code>5.45
 5.425
 6.1
 5.9
@@ -472,8 +498,8 @@ main()
 6.65
 6.625
 6.525
-</code></pre>
-</div>
+</code></pre></div>
+
 <p>And now we're done: the program now does everything we set out to do.</p>
 <h4 id="challenges-3">Challenges</h4>
 <ul>

--- a/06-cmdline.md
+++ b/06-cmdline.md
@@ -316,10 +316,12 @@ main()
   
 
 
-  + Using the function `list.files` introduced in a previous [lesson](03-loops-R.html), write a command-line program that lists all the files in the current directory that contain a specific pattern:
+  + Using the function `list.files` introduced in a previous [lesson](03-loops-R.html), write a command-line program, `find-pattern.R`, that lists all the files in the current directory that contain a specific pattern:
 
 
-<pre class='in'><code>Rscript find-pattern.R print-args</code></pre>
+<pre class='in'><code># For example, searching for the pattern "print-args" returns the two scripts we
+# wrote earlier
+Rscript find-pattern.R print-args</code></pre>
 
 
 

--- a/06-cmdline.md
+++ b/06-cmdline.md
@@ -12,7 +12,7 @@ In order to do that, we need to make our programs work like other Unix command-l
 For example, we may want a program that reads a data set and prints the average inflammation per patient:
 
 ~~~
-$ Rscript readings.R --mean inflammation-01.csv
+$ Rscript readings.R --mean data/inflammation-01.csv
 5.45
 5.425
 6.1
@@ -25,13 +25,13 @@ $ Rscript readings.R --mean inflammation-01.csv
 but we might also want to look at the minimum of the first four lines
 
 ~~~
-$ head -4 inflammation-01.csv | Rscript readings.R --min
+$ head -4 data/inflammation-01.csv | Rscript readings.R --min
 ~~~
 
 or the maximum inflammations in several files one after another:
 
 ~~~
-$ Rscript readings.R --max inflammation-*.csv
+$ Rscript readings.R --max data/inflammation-*.csv
 ~~~
 
 Our overall requirements are:
@@ -70,7 +70,7 @@ Now we can run the code in the file we created from the Unix Shell using `Rscrip
 
 
 
-<div class='out'><pre class='out'><code>R version 3.1.1 (2014-07-10)
+<div class='out'><pre class='out'><code>R version 3.1.2 (2014-10-31)
 Platform: x86_64-pc-linux-gnu (64-bit)
 
 locale:
@@ -112,7 +112,6 @@ Let's see what happens when we run this program in the Unix Shell:
 --slave
 --no-restore
 --file=print-args.R
---args
 </code></pre></div>
 
 From this output, we learn that `Rscript` is just a convenience command for running R scripts.
@@ -202,7 +201,7 @@ This function gets the name of the file to process from the first element return
 Here's a simple test to run from the Unix Shell:
 
 
-<pre class='in'><code>Rscript readings-01.R inflammation-01.csv</code></pre>
+<pre class='in'><code>Rscript readings-01.R data/inflammation-01.csv</code></pre>
 
 There is no output because we have defined a function, but haven't actually called it.
 Let's add a call to `main` and save it as `readings-02.R`:
@@ -220,7 +219,7 @@ main()
 </code></pre></div>
 
 
-<pre class='in'><code>Rscript readings-02.R inflammation-01.csv</code></pre>
+<pre class='in'><code>Rscript readings-02.R data/inflammation-01.csv</code></pre>
 
 
 
@@ -320,35 +319,13 @@ main()
   + Using the function `list.files` introduced in a previous [lesson](03-loops-R.html), write a command-line program that lists all the files in the current directory that contain a specific pattern:
 
 
-<pre class='in'><code>Rscript find-pattern.R inflammation</code></pre>
+<pre class='in'><code>Rscript find-pattern.R print-args</code></pre>
 
 
 
 
-<div class='out'><pre class='out'><code>inflammation-01.csv
-inflammation-01.pdf
-inflammation-02.csv
-inflammation-02.pdf
-inflammation-03.csv
-inflammation-03.pdf
-inflammation-04.csv
-inflammation-04.pdf
-inflammation-05.csv
-inflammation-05.pdf
-inflammation-06.csv
-inflammation-06.pdf
-inflammation-07.csv
-inflammation-07.pdf
-inflammation-08.csv
-inflammation-08.pdf
-inflammation-09.csv
-inflammation-09.pdf
-inflammation-10.csv
-inflammation-10.pdf
-inflammation-11.csv
-inflammation-11.pdf
-inflammation-12.csv
-inflammation-12.pdf
+<div class='out'><pre class='out'><code>print-args.R
+print-args-trailing.R
 </code></pre></div>
 
 
@@ -360,18 +337,18 @@ Since 60 lines of output per file is a lot to page through, we'll start by using
 Let's investigate them from the Unix Shell:
 
 
-<pre class='in'><code>ls small-*.csv</code></pre>
+<pre class='in'><code>ls data/small-*.csv</code></pre>
 
 
 
 
-<div class='out'><pre class='out'><code>small-01.csv
-small-02.csv
-small-03.csv
+<div class='out'><pre class='out'><code>data/small-01.csv
+data/small-02.csv
+data/small-03.csv
 </code></pre></div>
 
 
-<pre class='in'><code>cat small-01.csv</code></pre>
+<pre class='in'><code>cat data/small-01.csv</code></pre>
 
 
 
@@ -381,7 +358,7 @@ small-03.csv
 </code></pre></div>
 
 
-<pre class='in'><code>Rscript readings-02.R small-01.csv</code></pre>
+<pre class='in'><code>Rscript readings-02.R data/small-01.csv</code></pre>
 
 
 
@@ -416,7 +393,7 @@ main()
 and here it is in action:
 
 
-<pre class='in'><code>Rscript readings-03.R small-01.csv small-02.csv</code></pre>
+<pre class='in'><code>Rscript readings-03.R data/small-01.csv data/small-02.csv</code></pre>
 
 
 
@@ -471,7 +448,7 @@ main()
 And we can confirm this works by running it from the Unix Shell:
 
 
-<pre class='in'><code>Rscript readings-04.R --max small-01.csv</code></pre>
+<pre class='in'><code>Rscript readings-04.R --max data/small-01.csv</code></pre>
 
 
 
@@ -555,7 +532,7 @@ In this example, we passed it as an argument to the function `readLines`, which 
 Let's try running it from the Unix Shell as if it were a regular command-line program:
 
 
-<pre class='in'><code>Rscript count-stdin.R < small-01.csv</code></pre>
+<pre class='in'><code>Rscript count-stdin.R < data/small-01.csv</code></pre>
 
 
 
@@ -568,7 +545,7 @@ Note that because we did not specify `sep = "\n"` when calling `cat`, the output
 A common mistake is to try to run something that reads from standard input like this:
 
 
-<pre class='in'><code>Rscript count-stdin.R small-01.csv</code></pre>
+<pre class='in'><code>Rscript count-stdin.R data/small-01.csv</code></pre>
 
 i.e., to forget the `<` character that redirect the file to standard input.
 In this case, there's nothing in standard input, so the program waits at the start of the loop for someone to type something on the keyboard.
@@ -617,7 +594,7 @@ Let's try it out.
 Instead of calculating the mean inflammation of every patient, we'll only calculate the mean for the first 10 patients (rows):
 
 
-<pre class='in'><code>head inflammation-01.csv | Rscript readings-06.R --mean</code></pre>
+<pre class='in'><code>head data/inflammation-01.csv | Rscript readings-06.R --mean</code></pre>
 
 
 


### PR DESCRIPTION
I updated the last few instances where inflammation files were specified in the current working directory instead of in the subdirectory data/.  For the example of the exercise to write `find-pattern.R`, I simply changed the pattern since the inflammation files were no longer in the current working directory (listing the inflammation files via `list.files` would require passing two arguments). In my experience most novices already struggle with this lesson, so I did not want to make it any more complicated.