### PR TITLE
change example function name to not collide with base::outer function

### DIFF
--- a/02-func-R.Rmd
+++ b/02-func-R.Rmd
@@ -112,10 +112,10 @@ fence(best_practice, asterisk)
 ```
 
   + If the variable `v` refers to a vector, then `v[1]` is the vector's first element and `v[length(v)]` is its last (the function `length` returns the number of elements in a vector).
-    Write a function called `outer` that returns a vector made up of just the first and last elements of its input:
+    Write a function called `firstlast` that returns a vector made up of just the first and last elements of its input:
     
 ```{r, include=FALSE}
-outer <- function(v) {
+firstlast <- function(v) {
   first <- v[1]
   last <- v[length(v)]
   answer <- c(first, last)
@@ -125,7 +125,7 @@ outer <- function(v) {
 
 ```{r}
 dry_principle <- c("Don't", "repeat", "yourself", "or", "others")
-outer(dry_principle)
+firstlast(dry_principle)
 ```
 
 ### The Call Stack
@@ -220,13 +220,13 @@ That only works if functions don't interfere with each other; if they do, we hav
 
 #### Challenges
 
-  + We previously wrote functions called `fence` and `outer`.
+  + We previously wrote functions called `fence` and `firstlast`.
     Draw a diagram showing how the call stack changes when we run the following:
 
 ```{r, results="hide"}
 inside <- "carbon"
 outside <- "+"
-result <- outer(fence(inside, outside))
+result <- firstlast(fence(inside, outside))
 ```
 
 ### Testing and Documenting

--- a/02-func-R.Rmd
+++ b/02-func-R.Rmd
@@ -112,10 +112,10 @@ fence(best_practice, asterisk)
 ```
 
   + If the variable `v` refers to a vector, then `v[1]` is the vector's first element and `v[length(v)]` is its last (the function `length` returns the number of elements in a vector).
-    Write a function called `firstlast` that returns a vector made up of just the first and last elements of its input:
+    Write a function called `outside` that returns a vector made up of just the first and last elements of its input:
     
 ```{r, include=FALSE}
-firstlast <- function(v) {
+outside <- function(v) {
   first <- v[1]
   last <- v[length(v)]
   answer <- c(first, last)
@@ -125,7 +125,7 @@ firstlast <- function(v) {
 
 ```{r}
 dry_principle <- c("Don't", "repeat", "yourself", "or", "others")
-firstlast(dry_principle)
+outside(dry_principle)
 ```
 
 ### The Call Stack
@@ -220,13 +220,13 @@ That only works if functions don't interfere with each other; if they do, we hav
 
 #### Challenges
 
-  + We previously wrote functions called `fence` and `firstlast`.
+  + We previously wrote functions called `fence` and `outside`.
     Draw a diagram showing how the call stack changes when we run the following:
 
 ```{r, results="hide"}
 inside <- "carbon"
 outside <- "+"
-result <- firstlast(fence(inside, outside))
+result <- outside(fence(inside, outside))
 ```
 
 ### Testing and Documenting

--- a/02-func-R.html
+++ b/02-func-R.html
@@ -52,11 +52,11 @@
 <p>Let's try running our function. Calling our own function is no different from calling any other function:</p>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="co"># freezing point of water</span>
 <span class="kw">fahr_to_kelvin</span>(<span class="dv">32</span>)</code></pre>
-<pre class="output"><code>[1] 273.1
+<pre class="output"><code>[1] 273.15
 </code></pre>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="co"># boiling point of water</span>
 <span class="kw">fahr_to_kelvin</span>(<span class="dv">212</span>)</code></pre>
-<pre class="output"><code>[1] 373.1
+<pre class="output"><code>[1] 373.15
 </code></pre>
 <p>We've successfully called the function that we defined, and we have access to the value that we returned.</p>
 <h3 id="composing-functions">Composing Functions</h3>
@@ -68,7 +68,7 @@
 
 <span class="co">#absolute zero in Celsius</span>
 <span class="kw">kelvin_to_celsius</span>(<span class="dv">0</span>)</code></pre>
-<pre class="output"><code>[1] -273.1
+<pre class="output"><code>[1] -273.15
 </code></pre>
 <p>What about converting Fahrenheit to Celsius? We could write out the formula, but we don't need to. Instead, we can <a href="../../gloss.html#function-composition">compose</a> the two functions we have already created:</p>
 <pre class="sourceCode r"><code class="sourceCode r">fahr_to_celsius &lt;-<span class="st"> </span>function(temp) {
@@ -94,10 +94,10 @@ asterisk &lt;-<span class="st"> &quot;***&quot;</span>  <span class="co"># R int
 [7] &quot;computers&quot; &quot;***&quot;      
 </code></pre>
 <ul>
-<li>If the variable <code>v</code> refers to a vector, then <code>v[1]</code> is the vector's first element and <code>v[length(v)]</code> is its last (the function <code>length</code> returns the number of elements in a vector). Write a function called <code>outer</code> that returns a vector made up of just the first and last elements of its input:</li>
+<li>If the variable <code>v</code> refers to a vector, then <code>v[1]</code> is the vector's first element and <code>v[length(v)]</code> is its last (the function <code>length</code> returns the number of elements in a vector). Write a function called <code>outside</code> that returns a vector made up of just the first and last elements of its input:</li>
 </ul>
 <pre class="sourceCode r"><code class="sourceCode r">dry_principle &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="st">&quot;Don&#39;t&quot;</span>, <span class="st">&quot;repeat&quot;</span>, <span class="st">&quot;yourself&quot;</span>, <span class="st">&quot;or&quot;</span>, <span class="st">&quot;others&quot;</span>)
-<span class="kw">outer</span>(dry_principle)</code></pre>
+<span class="kw">outside</span>(dry_principle)</code></pre>
 <pre class="output"><code>[1] &quot;Don&#39;t&quot;  &quot;others&quot;
 </code></pre>
 <h3 id="the-call-stack">The Call Stack</h3>
@@ -121,7 +121,7 @@ final &lt;-<span class="st"> </span><span class="kw">fahr_to_celsius</span>(orig
 <p><img src="figure/python-call-stack-07.svg" alt="Call Stack After All Functions Have Finished" /></p>
 <p>This final stack frame is always there; it holds the variables we defined outside the functions in our code. What it <em>doesn't</em> hold is the variables that were in the various stack frames. If we try to get the value of <code>temp</code> after our functions have finished running, R tells us that there's no such thing:</p>
 <pre class="sourceCode r"><code class="sourceCode r">temp</code></pre>
-<pre class="output"><code>Error: object &#39;temp&#39; not found
+<pre class="output"><code>Error in eval(expr, envir, enclos): object &#39;temp&#39; not found
 </code></pre>
 <blockquote>
 <p><strong>Tip:</strong> The explanation of the stack frame above was very general and the basic concept will help you understand most languages you try to program with. However, R has some unique aspects that can be exploited when performing more complicated operations. We will not be writing anything that requires knowledge of these more advanced concepts. In the future when you are comfortable writing functions in R, you can learn more by reading the <a href="http://cran.r-project.org/doc/manuals/r-release/R-lang.html#Environment-objects">R Language Manual</a> or this <a href="http://adv-r.had.co.nz/Environments.html">chapter</a> from <a href="http://adv-r.had.co.nz/">Advanced R Programming</a> by Hadley Wickham. For context, R uses the terminology &quot;environments&quot; instead of frames.</p>
@@ -147,11 +147,13 @@ dat &lt;-<span class="st"> </span><span class="kw">read.csv</span>(<span class="
 <p>The big idea here is <a href="../../gloss.html#encapsulation">encapsulation</a>, and it's the key to writing correct, comprehensible programs. A function's job is to turn several operations into one so that we can think about a single function call instead of a dozen or a hundred statements each time we want to do something. That only works if functions don't interfere with each other; if they do, we have to pay attention to the details once again, which quickly overloads our short-term memory.</p>
 <h4 id="challenges-1">Challenges</h4>
 <ul>
-<li>We previously wrote functions called <code>fence</code> and <code>outer</code>. Draw a diagram showing how the call stack changes when we run the following:</li>
+<li>We previously wrote functions called <code>fence</code> and <code>outside</code>. Draw a diagram showing how the call stack changes when we run the following:</li>
 </ul>
 <pre class="sourceCode r"><code class="sourceCode r">inside &lt;-<span class="st"> &quot;carbon&quot;</span>
 outside &lt;-<span class="st"> &quot;+&quot;</span>
-result &lt;-<span class="st"> </span><span class="kw">outer</span>(<span class="kw">fence</span>(inside, outside))</code></pre>
+result &lt;-<span class="st"> </span><span class="kw">outside</span>(<span class="kw">fence</span>(inside, outside))</code></pre>
+<pre class="output"><code>Error in eval(expr, envir, enclos): could not find function &quot;outside&quot;
+</code></pre>
 <h3 id="testing-and-documenting">Testing and Documenting</h3>
 <p>Once we start putting things in functions so that we can re-use them, we need to start testing that those functions are working correctly. To see how to do this, let's write a function to center a dataset around a particular value:</p>
 <pre class="sourceCode r"><code class="sourceCode r">center &lt;-<span class="st"> </span>function(data, desired) {
@@ -200,11 +202,11 @@ centered &lt;-<span class="st"> </span><span class="kw">center</span>(dat[, <spa
 <p>That seems almost right: the original mean was about 1.75, so the lower bound from zero is now about -1.75. The mean of the centered data is 0. We can even go further and check that the standard deviation hasn't changed:</p>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="co"># original standard deviation</span>
 <span class="kw">sd</span>(dat[, <span class="dv">4</span>])</code></pre>
-<pre class="output"><code>[1] 1.068
+<pre class="output"><code>[1] 1.067628
 </code></pre>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="co"># centerted standard deviation</span>
 <span class="kw">sd</span>(centered)</code></pre>
-<pre class="output"><code>[1] 1.068
+<pre class="output"><code>[1] 1.067628
 </code></pre>
 <p>Those values look the same, but we probably wouldn't notice if they were different in the sixth decimal place. Let's do this instead:</p>
 <pre class="sourceCode r"><code class="sourceCode r"><span class="co"># difference in standard deviations before and after</span>
@@ -241,7 +243,7 @@ centered &lt;-<span class="st"> </span><span class="kw">center</span>(dat[, <spa
 <p>However, the position of the arguments matters if they are not named.</p>
 <pre class="sourceCode r"><code class="sourceCode r">dat &lt;-<span class="st"> </span><span class="kw">read.csv</span>(<span class="dt">header =</span> <span class="ot">FALSE</span>, <span class="dt">file =</span> <span class="st">&quot;data/inflammation-01.csv&quot;</span>)
 dat &lt;-<span class="st"> </span><span class="kw">read.csv</span>(<span class="ot">FALSE</span>, <span class="st">&quot;data/inflammation-01.csv&quot;</span>)</code></pre>
-<pre class="output"><code>Error: &#39;file&#39; must be a character string or connection
+<pre class="output"><code>Error in read.table(file = file, header = header, sep = sep, quote = quote, : &#39;file&#39; must be a character string or connection
 </code></pre>
 <p>To understand what's going on, and make our own functions easier to use, let's re-define our <code>center</code> function like this:</p>
 <pre class="sourceCode r"><code class="sourceCode r">center &lt;-<span class="st"> </span>function(data, <span class="dt">desired =</span> <span class="dv">0</span>) {
@@ -314,7 +316,7 @@ more_data</code></pre>
          <span class="dt">dec =</span> <span class="st">&quot;.&quot;</span>, <span class="dt">fill =</span> <span class="ot">TRUE</span>, <span class="dt">comment.char =</span> <span class="st">&quot;&quot;</span>, ...)</code></pre>
 <p>This tells us that <code>read.csv()</code> has one argument, <code>file</code>, that doesn't have a default value, and six others that do. Now we understand why the following gives an error:</p>
 <pre class="sourceCode r"><code class="sourceCode r">dat &lt;-<span class="st"> </span><span class="kw">read.csv</span>(<span class="ot">FALSE</span>, <span class="st">&quot;data/inflammation-01.csv&quot;</span>)</code></pre>
-<pre class="output"><code>Error: &#39;file&#39; must be a character string or connection
+<pre class="output"><code>Error in read.table(file = file, header = header, sep = sep, quote = quote, : &#39;file&#39; must be a character string or connection
 </code></pre>
 <p>It fails because <code>FALSE</code> is assigned to <code>file</code> and the filename is assigned to the argument <code>header</code>.</p>
 <h4 id="challenges-3">Challenges</h4>

--- a/02-func-R.md
+++ b/02-func-R.md
@@ -57,7 +57,7 @@ fahr_to_kelvin(32)
 
 
 ~~~{.output}
-[1] 273.1
+[1] 273.15
 
 ~~~
 
@@ -71,7 +71,7 @@ fahr_to_kelvin(212)
 
 
 ~~~{.output}
-[1] 373.1
+[1] 373.15
 
 ~~~
 
@@ -95,7 +95,7 @@ kelvin_to_celsius(0)
 
 
 ~~~{.output}
-[1] -273.1
+[1] -273.15
 
 ~~~
 
@@ -150,14 +150,14 @@ fence(best_practice, asterisk)
 ~~~
 
   + If the variable `v` refers to a vector, then `v[1]` is the vector's first element and `v[length(v)]` is its last (the function `length` returns the number of elements in a vector).
-    Write a function called `outer` that returns a vector made up of just the first and last elements of its input:
+    Write a function called `outside` that returns a vector made up of just the first and last elements of its input:
     
 
 
 
 ~~~{.r}
 dry_principle <- c("Don't", "repeat", "yourself", "or", "others")
-outer(dry_principle)
+outside(dry_principle)
 ~~~
 
 
@@ -224,7 +224,7 @@ temp
 
 
 ~~~{.output}
-Error: object 'temp' not found
+Error in eval(expr, envir, enclos): object 'temp' not found
 
 ~~~
 
@@ -284,14 +284,21 @@ That only works if functions don't interfere with each other; if they do, we hav
 
 #### Challenges
 
-  + We previously wrote functions called `fence` and `outer`.
+  + We previously wrote functions called `fence` and `outside`.
     Draw a diagram showing how the call stack changes when we run the following:
 
 
 ~~~{.r}
 inside <- "carbon"
 outside <- "+"
-result <- outer(fence(inside, outside))
+result <- outside(fence(inside, outside))
+~~~
+
+
+
+~~~{.output}
+Error in eval(expr, envir, enclos): could not find function "outside"
+
 ~~~
 
 ### Testing and Documenting
@@ -451,7 +458,7 @@ sd(dat[, 4])
 
 
 ~~~{.output}
-[1] 1.068
+[1] 1.067628
 
 ~~~
 
@@ -465,7 +472,7 @@ sd(centered)
 
 
 ~~~{.output}
-[1] 1.068
+[1] 1.067628
 
 ~~~
 
@@ -564,7 +571,7 @@ dat <- read.csv(FALSE, "data/inflammation-01.csv")
 
 
 ~~~{.output}
-Error: 'file' must be a character string or connection
+Error in read.table(file = file, header = header, sep = sep, quote = quote, : 'file' must be a character string or connection
 
 ~~~
 
@@ -745,7 +752,7 @@ dat <- read.csv(FALSE, "data/inflammation-01.csv")
 
 
 ~~~{.output}
-Error: 'file' must be a character string or connection
+Error in read.table(file = file, header = header, sep = sep, quote = quote, : 'file' must be a character string or connection
 
 ~~~
 


### PR DESCRIPTION
`outer` is already defined in base. This just offered us the opportunity to caution about redefining built-in names for R, but it's probably best to not redefine built-in base R functions.