### PR TITLE
Fix bug with function `outside`

### DIFF
--- a/02-func-R.Rmd
+++ b/02-func-R.Rmd
@@ -230,9 +230,9 @@ That only works if functions don't interfere with each other; if they do, we hav
 >following:
 
 ```{r, results="hide"}
-inside <- "carbon"
-outside <- "+"
-result <- outside(fence(inside, outside))
+inner_vec <- "carbon"
+outer_vec <- "+"
+result <- outside(fence(inner_vec, outer_vec))
 ```
 
 ### Testing and Documenting


### PR DESCRIPTION
Avoid error from overwriting function `outside` with the vector of the same name.