### PR TITLE
Modifying Makefile to keep Markdown generated from R.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ INCLUDES = \
 # Chunk options for knitr (used in R conversion).
 R_CHUNK_OPTS = tools/chunk-options.R
 
+# Ensure that intermediate (generated) Markdown files from R are kept.
+.SECONDARY: $(DST_RMD)
+
 # Default action is to show what commands are available.
 all : commands
 


### PR DESCRIPTION
See http://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_10.html#IDX825 for an explanation of the use of `.SECONDARY`.