### PR TITLE
Add common gotchas with git in RStudio to instructor notes

### DIFF
--- a/instructors.Rmd
+++ b/instructors.Rmd
@@ -307,9 +307,11 @@ cat line-count.R
 
 Some instructors will demo RStudio's git integration at some point during the
 workshop. This often goes over very well, but there can be a few snags with the
-setup. First, RStudio may not know where to find git. You can specify where git
-is located in _Tools > Global Options > Git/SVN_; on Mac/Linux git is often in
-`usr/bin/git` or `usr/local/bin/git` and on Windows it is often in
+setup. First, RStudio may not know where to find git (this shouldn't be a
+problem for Windows users who installed Git Bash and selected the option to run
+Git from the Windows command prompt). You can specify where git is located in
+_Tools > Global Options > Git/SVN_; on Mac/Linux git is often in `usr/bin/git`
+or `usr/local/bin/git` and on Windows it is often in
 `C:/Program Files (x86)/Git/bin/git.exe`. If you don't know where git is
 installed on someone's computer, open a terminal and try `which git` on
 Mac/Linux, or `where git` or `whereis git.exe` on Windows. See

--- a/instructors.Rmd
+++ b/instructors.Rmd
@@ -307,16 +307,20 @@ cat line-count.R
 
 Some instructors will demo RStudio's git integration at some point during the
 workshop. This often goes over very well, but there can be a few snags with the
-setup. First, RStudio may not know where to find git (this shouldn't be a
-problem for Windows users who installed Git Bash and selected the option to run
-Git from the Windows command prompt). You can specify where git is located in
-_Tools > Global Options > Git/SVN_; on Mac/Linux git is often in `usr/bin/git`
-or `usr/local/bin/git` and on Windows it is often in
+setup. First, RStudio may not know where to find git. You can specify where git
+is located in _Tools > Global Options > Git/SVN_; on Mac/Linux git is often in
+`usr/bin/git` or `usr/local/bin/git` and on Windows it is often in
 `C:/Program Files (x86)/Git/bin/git.exe`. If you don't know where git is
 installed on someone's computer, open a terminal and try `which git` on
 Mac/Linux, or `where git` or `whereis git.exe` on Windows. See
 [Jenny Bryan's instructions](http://stat545-ubc.github.io/git03_rstudio-meet-git.html)
 for more detail.
+
+If Windows users select the option "Run Git from the Windows command prompt"
+while setting up Git Bash, RStudio will automatically find the git executable.
+If you plan to demo git in RStudio during your workshop, you should edit the
+workshop setup instructions to have the Windows users choose this option during
+setup.
 
 Another common gotcha is that the push/pull buttons in RStudio are grayed out,
 even after you have added a remote and pushed to it from the command line. You

--- a/instructors.Rmd
+++ b/instructors.Rmd
@@ -303,3 +303,21 @@ cat line-count.R
 
 ## [Making Packages in R](08-making-packages-R.html)
 
+## Using Git in RStudio
+
+Some instructors will demo RStudio's git integration at some point during the
+workshop. This often goes over very well, but there can be a few snags with the
+setup. First, RStudio may not know where to find git. You can specify where git
+is located in _Tools > Global Options > Git/SVN_; on Mac/Linux git is often in
+`usr/bin/git` or `usr/local/bin/git` and on Windows it is often in
+`C:/Program Files (x86)/Git/bin/git.exe`. If you don't know where git is
+installed on someone's computer, open a terminal and try `which git` on
+Mac/Linux, or `where git` or `whereis git.exe` on Windows. See
+[Jenny Bryan's instructions](http://stat545-ubc.github.io/git03_rstudio-meet-git.html)
+for more detail.
+
+Another common gotcha is that the push/pull buttons in RStudio are grayed out,
+even after you have added a remote and pushed to it from the command line. You
+need to add an upstream tracking reference before you can push and pull directly
+from RStudio; have your learners do `git push -u origin master` from the command
+line and this should resolve the issue.

--- a/instructors.md
+++ b/instructors.md
@@ -616,3 +616,21 @@ main()
 
 ## [Making Packages in R](08-making-packages-R.html)
 
+## Using Git in RStudio
+
+Some instructors will demo RStudio's git integration at some point during the
+workshop. This often goes over very well, but there can be a few snags with the
+setup. First, RStudio may not know where to find git. You can specify where git
+is located in _Tools > Global Options > Git/SVN_; on Mac/Linux git is often in
+`usr/bin/git` or `usr/local/bin/git` and on Windows it is often in
+`C:/Program Files (x86)/Git/bin/git.exe`. If you don't know where git is
+installed on someone's computer, open a terminal and try `which git` on
+Mac/Linux, or `where git` or `whereis git.exe` on Windows. See
+[Jenny Bryan's instructions](http://stat545-ubc.github.io/git03_rstudio-meet-git.html)
+for more detail.
+
+Another common gotcha is that the push/pull buttons in RStudio are grayed out,
+even after you have added a remote and pushed to it from the command line. You
+need to add an upstream tracking reference before you can push and pull directly
+from RStudio; have your learners do `git push -u origin master` from the command
+line and this should resolve the issue.

--- a/instructors.md
+++ b/instructors.md
@@ -620,16 +620,20 @@ main()
 
 Some instructors will demo RStudio's git integration at some point during the
 workshop. This often goes over very well, but there can be a few snags with the
-setup. First, RStudio may not know where to find git (this shouldn't be a
-problem for Windows users who installed Git Bash and selected the option to run
-Git from the Windows command prompt). You can specify where git is located in
-_Tools > Global Options > Git/SVN_; on Mac/Linux git is often in `usr/bin/git`
-or `usr/local/bin/git` and on Windows it is often in
+setup. First, RStudio may not know where to find git. You can specify where git
+is located in _Tools > Global Options > Git/SVN_; on Mac/Linux git is often in
+`usr/bin/git` or `usr/local/bin/git` and on Windows it is often in
 `C:/Program Files (x86)/Git/bin/git.exe`. If you don't know where git is
 installed on someone's computer, open a terminal and try `which git` on
 Mac/Linux, or `where git` or `whereis git.exe` on Windows. See
 [Jenny Bryan's instructions](http://stat545-ubc.github.io/git03_rstudio-meet-git.html)
 for more detail.
+
+If Windows users select the option "Run Git from the Windows command prompt"
+while setting up Git Bash, RStudio will automatically find the git executable.
+If you plan to demo git in RStudio during your workshop, you should edit the
+workshop setup instructions to have the Windows users choose this option during
+setup.
 
 Another common gotcha is that the push/pull buttons in RStudio are grayed out,
 even after you have added a remote and pushed to it from the command line. You

--- a/instructors.md
+++ b/instructors.md
@@ -620,9 +620,11 @@ main()
 
 Some instructors will demo RStudio's git integration at some point during the
 workshop. This often goes over very well, but there can be a few snags with the
-setup. First, RStudio may not know where to find git. You can specify where git
-is located in _Tools > Global Options > Git/SVN_; on Mac/Linux git is often in
-`usr/bin/git` or `usr/local/bin/git` and on Windows it is often in
+setup. First, RStudio may not know where to find git (this shouldn't be a
+problem for Windows users who installed Git Bash and selected the option to run
+Git from the Windows command prompt). You can specify where git is located in
+_Tools > Global Options > Git/SVN_; on Mac/Linux git is often in `usr/bin/git`
+or `usr/local/bin/git` and on Windows it is often in
 `C:/Program Files (x86)/Git/bin/git.exe`. If you don't know where git is
 installed on someone's computer, open a terminal and try `which git` on
 Mac/Linux, or `where git` or `whereis git.exe` on Windows. See


### PR DESCRIPTION
Two frequent issues with using git in RStudio are making sure RStudio knows where to find git and making sure to set an upstream reference so that RStudio can push and pull directly to/from GitHub.