### PR TITLE
Change misleading wording about return statements

### DIFF
--- a/02-func-R.Rmd
+++ b/02-func-R.Rmd
@@ -45,7 +45,7 @@ Inside the function, we use a [return statement](reference.html#return-statement
 
 > ## Tip {.callout}
 >
-> One feature unique to R is that the return statement is not required.
+> In R, it is not necessary to include the return statement.
 > R automatically returns whichever variable is on the last line of the body
 > of the function. Since we are just learning, we will explicitly define the
 > return statement.


### PR DESCRIPTION
Implicit returns are not unique to R. New wording is more general.