### PR TITLE
Refer to array-extent as 'dimension'

### DIFF
--- a/01-starting-with-data.Rmd
+++ b/01-starting-with-data.Rmd
@@ -181,7 +181,7 @@ class(dat)
 The output tells us that is a data frame. Think of this structure as a spreadsheet in MS Excel that many of us are familiar with.
 Data frames are very useful for storing data and you will find them elsewhere when programming in R. A typical data frame of experimental data contains individual observations in rows and variables in columns.
 
-We can see the dimensions, or [shape](reference.html#shape-(of-an-array)), of the data frame with the function `dim`:
+We can see the shape, or [dimensions](reference.html#dimensions-(of-an-array)), of the data frame with the function `dim`:
 
 ```{r}
 dim(dat)

--- a/01-starting-with-data.md
+++ b/01-starting-with-data.md
@@ -286,7 +286,7 @@ class(dat)
 The output tells us that is a data frame. Think of this structure as a spreadsheet in MS Excel that many of us are familiar with.
 Data frames are very useful for storing data and you will find them elsewhere when programming in R. A typical data frame of experimental data contains individual observations in rows and variables in columns.
 
-We can see the shape, or [dimensions](reference.html#dimensions-(of-an-array)), of the data frame with the function `dim`:
+We can see the dimensions, or [shape](reference.html#shape-(of-an-array)), of the data frame with the function `dim`:
 
 
 ~~~{.r}

--- a/01-starting-with-data.md
+++ b/01-starting-with-data.md
@@ -286,7 +286,7 @@ class(dat)
 The output tells us that is a data frame. Think of this structure as a spreadsheet in MS Excel that many of us are familiar with.
 Data frames are very useful for storing data and you will find them elsewhere when programming in R. A typical data frame of experimental data contains individual observations in rows and variables in columns.
 
-We can see the dimensions, or [shape](reference.html#shape-(of-an-array)), of the data frame with the function `dim`:
+We can see the shape, or [dimensions](reference.html#dimensions-(of-an-array)), of the data frame with the function `dim`:
 
 
 ~~~{.r}

--- a/reference.md
+++ b/reference.md
@@ -115,6 +115,9 @@ comment
 conditional statement
 :   A statement in a program that might or might not be executed depending on whether a test is true or false.
 
+dimensions (of an array)
+:   An array's extent, represented as a vector. For example, an array with 5 rows and 3 columns has dimensions `(5,3)`.
+
 documentation
 :   Human-language text written to explain what software does, how it works, or how to use it.
 
@@ -150,9 +153,6 @@ pipe
 
 return statement
 :   A statement that causes a function to stop executing and return a value to its caller immediately.
-
-shape (of an array)
-:   An array's dimensions, represented as a vector. For example, a 5&times;3 array's shape is `(5,3)`.
 
 silent failure
 :   Failing without producing any warning messages. Silent failures are hard to detect and debug.


### PR DESCRIPTION
This addresses issue #139 -- that R-speak generally uses "dimension" rather than "shape" to describe the extent of an array.

This is my tiny pull request to move the instructor training process forward. How do I now I arrange to do the teaching demo?