### PR TITLE
use as.numeric() to convert row of data.frame to vector

### DIFF
--- a/01-starting-with-data.Rmd
+++ b/01-starting-with-data.Rmd
@@ -240,6 +240,19 @@ patient_1 <- dat[1, ]
 max(patient_1)
 ```
 
+> ## Tip {.callout}
+>
+> On some installations of R, the code above may give you an error, since R does not automatically convert a sliced row of a `data.frame` to a vector. (Confusingly, sliced columns are automatically converted.)
+> If this happens, you can use the `as.numeric` command to convert the row of data to a numeric vector:
+> 
+> `patient_1 <- as.numeric(dat[1, ])`
+> `max(patient_1)`
+>
+> You can also check the `class` of each object:
+>
+> `class(dat[1, ])`
+> `class(as.numeric(dat[1, ]))`
+
 We don't actually need to store the row in a variable of its own.
 Instead, we can combine the selection and the function call:
 


### PR DESCRIPTION
On some installations of R, running commands such as max / min / mean on a sliced row of a data.frame returns an error, since R does not automatically convert the row of data to a numeric vector (confusingly, columns are automatically converted). During a recent workshop we solved this by using the as.numeric() command. I have added a Tip explaining this issue and suggesting the use of as.numeric() if others encounter the same problem.