### PR TITLE
r-novice-inflammation modified in 04-cond files

### DIFF
--- a/04-cond.Rmd
+++ b/04-cond.Rmd
@@ -143,7 +143,7 @@ sign(0)
 sign(2/3)
 ```
 
-Note that when combining 'else' and 'if' in an 'else if' statement (similar to 'elif' in Python), the 'if' portion still requires a direct input condition.  This is never the case for the 'else' statement alone, which is only executed if all other conditions go unsatisfied. 
+Note that when combining `else` and `if` in an `else if` statement (similar to `elif` in Python), the `if` portion still requires a direct input condition.  This is never the case for the `else` statement alone, which is only executed if all other conditions go unsatisfied. 
 Note that the test for equality uses two equal signs, `==`.
 
 > ## Tip {.callout}

--- a/04-cond.Rmd
+++ b/04-cond.Rmd
@@ -143,6 +143,7 @@ sign(0)
 sign(2/3)
 ```
 
+Note that when combining 'else' and 'if' in an 'else if' statement (similar to 'elif' in Python), the 'if' portion still requires a direct input condition.  This is never the case for the 'else' statement alone, which is only executed if all other conditions go unsatisfied. 
 Note that the test for equality uses two equal signs, `==`.
 
 > ## Tip {.callout}

--- a/04-cond.html
+++ b/04-cond.html
@@ -125,7 +125,7 @@ if (num &gt;<span class="st"> </span><span class="dv">100</span>) {
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">sign</span>(<span class="dv">2</span>/<span class="dv">3</span>)</code></pre>
 <pre class="output"><code>[1] 1
 </code></pre>
-<p>Note that when combining 'else' and 'if' in an 'else if' statement (similar to 'elif' in Python), the 'if' portion still requires a direct input condition.  This is never the case for the 'else' statement alone, which is only executed if all other conditions go unsatisfied.  Note that the test for equality uses two equal signs, <code>==</code>.</p>
+<p>Note that when combining <code>else</code> and <code>if</code> in an <code>else if</code> statement (similar to <code>elif</code> in Python), the <code>if</code> portion still requires a direct input condition.  This is never the case for the <code>else</code> statement alone, which is only executed if all other conditions go unsatisfied.  Note that the test for equality uses two equal signs, <code>==</code>.</p>
 <aside class="callout panel panel-info">
 <div class="panel-heading">
 <h2><span class="glyphicon glyphicon-pushpin"></span>Tip</h2>

--- a/04-cond.html
+++ b/04-cond.html
@@ -125,7 +125,7 @@ if (num &gt;<span class="st"> </span><span class="dv">100</span>) {
 <pre class="sourceCode r"><code class="sourceCode r"><span class="kw">sign</span>(<span class="dv">2</span>/<span class="dv">3</span>)</code></pre>
 <pre class="output"><code>[1] 1
 </code></pre>
-<p>Note that the test for equality uses two equal signs, <code>==</code>.</p>
+<p>Note that when combining 'else' and 'if' in an 'else if' statement (similar to 'elif' in Python), the 'if' portion still requires a direct input condition.  This is never the case for the 'else' statement alone, which is only executed if all other conditions go unsatisfied.  Note that the test for equality uses two equal signs, <code>==</code>.</p>
 <aside class="callout panel panel-info">
 <div class="panel-heading">
 <h2><span class="glyphicon glyphicon-pushpin"></span>Tip</h2>

--- a/04-cond.md
+++ b/04-cond.md
@@ -201,7 +201,7 @@ sign(2/3)
 
 ~~~
 
-Note that the test for equality uses two equal signs, `==`.
+Note that when combining 'else' and 'if' in an 'else if' statement (similar to 'elif' in Python), the 'if' portion still requires a direct input condition.  This is never the case for the 'else' statement alone, which is only executed if all other conditions go unsatisfied.  Note that the test for equality uses two equal signs, `==`.
 
 > ## Tip {.callout}
 >

--- a/04-cond.md
+++ b/04-cond.md
@@ -201,7 +201,7 @@ sign(2/3)
 
 ~~~
 
-Note that when combining 'else' and 'if' in an 'else if' statement (similar to 'elif' in Python), the 'if' portion still requires a direct input condition.  This is never the case for the 'else' statement alone, which is only executed if all other conditions go unsatisfied.  Note that the test for equality uses two equal signs, `==`.
+Note that when combining `else` and `if` in an `else if` statement (similar to `elif` in Python), the `if` portion still requires a direct input condition.  This is never the case for the `else` statement alone, which is only executed if all other conditions go unsatisfied.  Note that the test for equality uses two equal signs, `==`.
 
 > ## Tip {.callout}
 >


### PR DESCRIPTION
Added comment about 'else if' statements in 04-cond.* files.  Specific text added was:
"Note that when combining `else` and `if` in an `else if` statement (similar to `elif` in Python), the `if` portion still requires a direct input condition.  This is never the case for the `else` statement alone, which is only executed if all other conditions go unsatisfied."