### PR TITLE
Edit analyze_all function in lesson 04-cond.Rmd

### DIFF
--- a/04-cond.Rmd
+++ b/04-cond.Rmd
@@ -251,36 +251,61 @@ is.null(output)
 !is.null(output)
 ```
 
-Now we can use `analyze` both interactively:
+Now we can use `analyze` interactively, as before,
 
 ```{r inflammation-01}
 analyze("data/inflammation-01.csv")
 ```
 
-and to save plots:
+but also use it to save plots,
 
 ```{r results='hide'}
 analyze("data/inflammation-01.csv", output = "inflammation-01.pdf")
 ```
 
-This now works well when we want to process one data file at a time, but how can we specify the output file in `analyze_all`?
-We need to substitute the filename ending "csv" with "pdf", which we can do using the function `sub`:
+Before going further, we will create a directory `results` for saving our plots.
+It is [good practice](http://swcarpentry.github.io/good-enough-practices-in-scientific-computing/) in data analysis projects to save all output to a directory seperate from the data and analysis code.
+You can create this directory using the shell command [mkdir](http://swcarpentry.github.io/shell-novice/02-create.html), or the R function `dir.create()`
+```{r warning=FALSE}
+dir.create("results")
+```
 
+Now run `analyze` and save the plot in the `results` directory,
+```{r results='hide'}
+analyze("data/inflammation-01.csv", output = "results/inflammation-01.pdf")
+```
+
+This now works well when we want to process one data file at a time, but how can we specify the output file in `analyze_all`?
+We need to do two things:
+
+1. Substitute the filename ending "csv" with "pdf".
+2. Save the plot to the `results` directory.
+
+To change the extension to "pdf", we will use the function `sub`,
 ```{r}
-f <- "data/inflammation-01.csv"
+f <- "inflammation-01.csv"
 sub("csv", "pdf", f)
 ```
+To add the "data" directory to the filename use the function `file.path`,
+```{r}
+file.path("results", sub("csv", "pdf", f))
+```
+
 
 Now let's update `analyze_all`:
 
 ```{r analyze_all-save}
 analyze_all <- function(pattern) {
+  # Directory name containing the data
+  data_dir <- "data"
+  # Directory name for results
+  results_dir <- "results"
   # Runs the function analyze for each file in the current working directory
   # that contains the given pattern.
-  filenames <- list.files(path = "data", pattern = pattern, full.names = TRUE)
+  filenames <- list.files(path = data_dir, pattern = pattern)
   for (f in filenames) {
-    pdf_name <- sub("csv", "pdf", f)
-    analyze(f, output = pdf_name)
+    pdf_name <- file.path(results_dir, sub("csv", "pdf", f))
+    analyze(file.path(data_dir, f), output = pdf_name)
   }
 }
 ```
@@ -291,7 +316,7 @@ Now we can save all of the results with just one line of code:
 analyze_all("inflammation")
 ```
 
-Now if we need to make any changes to our analysis, we can edit the `analyze` function and quickly regenerate all the figures with `analzye_all`.
+Now if we need to make any changes to our analysis, we can edit the `analyze` function and quickly regenerate all the figures with `analyze_all`.
 
 > ## Challenge - Changing the behaviour of the plot command {.challenge}
 >


### PR DESCRIPTION
The analyze_all function would save files in the same directory as the data csv files.
This would cause problems on repeated runs without updating the pattern used to select files. Since using a pattern to only get csv files matching inflation.*\\.csv would require mentioning regular expressions, I opted to fix this by saving the figures to a different directory.

I also used this as an opportunity to reference the good scienctific computing practice of separating data and output referenced in "Good Enough Practices for Scientific Computing."

This fixes issue #169.