### PR TITLE
05-cmdline: do not link to a page about kill

### DIFF
--- a/_episodes/05-cmdline.md
+++ b/_episodes/05-cmdline.md
@@ -813,9 +813,9 @@ Rscript count-stdin.R data/small-01.csv
 i.e., to forget the `<` character that redirect the file to standard input.
 In this case, there's nothing in standard input, so the program waits at the start of the loop for someone to type something on the keyboard.
 We can type some input, but R keeps running because it doesn't know when the standard input has ended.
-If you ran this, you can pause R by typing `ctrl`+`z` (technically it is still paused in the background; if you want to fully kill the process follow these [instructions][ps-kill]).
+If you ran this, you can pause R by typing `ctrl`+`z` (technically it is still paused in the background; if you want to fully kill the process type `kill %`; see [bash manual][bash-jobs] for more information)).
 
-[ps-kill]: http://linux.about.com/library/cmd/blcmdl_kill.htm
+[bash-jobs]: https://www.gnu.org/software/bash/manual/bash.html#Job-Control-Basics
 
 We now need to rewrite the program so that it loads data from `file("stdin")` if no filenames are provided.
 Luckily, `read.csv` can handle either a filename or an open file as its first parameter, so we don't actually need to change `process`.

--- a/_episodes_rmd/05-cmdline.Rmd
+++ b/_episodes_rmd/05-cmdline.Rmd
@@ -347,9 +347,9 @@ Rscript count-stdin.R data/small-01.csv
 i.e., to forget the `<` character that redirect the file to standard input.
 In this case, there's nothing in standard input, so the program waits at the start of the loop for someone to type something on the keyboard.
 We can type some input, but R keeps running because it doesn't know when the standard input has ended.
-If you ran this, you can pause R by typing `ctrl`+`z` (technically it is still paused in the background; if you want to fully kill the process follow these [instructions][ps-kill]).
+If you ran this, you can pause R by typing `ctrl`+`z` (technically it is still paused in the background; if you want to fully kill the process type `kill %`; see [bash manual][bash-jobs] for more information)).
 
-[ps-kill]: http://linux.about.com/library/cmd/blcmdl_kill.htm
+[bash-jobs]: https://www.gnu.org/software/bash/manual/bash.html#Job-Control-Basics
 
 We now need to rewrite the program so that it loads data from `file("stdin")` if no filenames are provided.
 Luckily, `read.csv` can handle either a filename or an open file as its first parameter, so we don't actually need to change `process`.


### PR DESCRIPTION
There is no need to refer to search through ps aux output, and the
page that was linked wasn't even particularly useful, since 'kill %'
works nicely under most shells. Linked page also suggested using
ctrl-alt-esc, which (I'm guessing) invokes something equivalent to
xkill in some graphical environments. Using this would likely
terminate the terminal or Rstudio, which is definitely not what we
want.