### PR TITLE
Fixes for challenge "Named Variables and Scope of Variables" from episode Creating Function

### DIFF
--- a/_episodes/02-func-R.md
+++ b/_episodes/02-func-R.md
@@ -248,7 +248,7 @@ Real-life functions will usually be larger than the ones shown here--typically h
 >     2. 11
 >     3. 23
 >     4. 30
-> 2.  If mySum(3) == 13, why does mySum(b=3) return an error?
+> 2.  If mySum(3) == 13, why does `mySum(input_2 = 3)` return an error?
 {: .challenge}
 
 ### Testing and Documenting

--- a/_episodes/02-func-R.md
+++ b/_episodes/02-func-R.md
@@ -248,7 +248,7 @@ Real-life functions will usually be larger than the ones shown here--typically h
 >     2. 11
 >     3. 23
 >     4. 30
-> 2.  If mySum(3) == 13, why does `mySum(input_2 = 3)` return an error?
+> 2.  If `mySum(3)` returns 13, why does `mySum(input_2 = 3)` return an error?
 {: .challenge}
 
 ### Testing and Documenting


### PR DESCRIPTION
This pull-request includes two fixes
- Fix the named argument in the second part of the challenge, where we used to read mySum(b=3), we should now read `mySum(input_2 = 3)`. Naming the second argument `b` does return an error, but I doubt it was the error the author originally intended to invoke. I am guessing the arguments were renamed from `mySum(a, b)` to `mySum(input_1, input_2)`, but this part was forgotten.
- Fix the formatting by using back-quotes when referring to `mySum` in the second exercise.