### PR TITLE
Adding auto-generated IDs

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -109,6 +109,7 @@ increment_me <- function(value_to_increment, value_to_increment_by = 1){
 
 ## Glossary
 
+{:auto_ids}
 argument
 :   A value given to a function or program when it runs. The term is often used interchangeably (and inconsistently) with [parameter](#parameter).
 


### PR DESCRIPTION
The new version of Kramdown will add IDs to glossary entries (definition lists) if instructed to do so.