### PR TITLE
fix anchor links

### DIFF
--- a/_episodes_rmd/01-starting-with-data.Rmd
+++ b/_episodes_rmd/01-starting-with-data.Rmd
@@ -36,7 +36,7 @@ knitr_fig_path("01-starting-with-data-")
 
 We are studying inflammation in patients who have been given a new treatment for arthritis,
 and need to analyze the first dozen data sets.
-The data sets are stored in [comma-separated values]({{ page.root }}/reference/#comma-separated-values-(csv)) (CSV) format. Each row holds the observations for just one patient. Each column holds the inflammation measured in a day, so we have a set of values in successive days.
+The data sets are stored in [comma-separated values]({{ page.root }}/reference/#comma-separated-values-csv) (CSV) format. Each row holds the observations for just one patient. Each column holds the inflammation measured in a day, so we have a set of values in successive days.
 The first few rows of our first file look like this:
 
 ```{r echo = FALSE}
@@ -223,7 +223,7 @@ class(dat)
 The output tells us that is a data frame. Think of this structure as a spreadsheet in MS Excel that many of us are familiar with.
 Data frames are very useful for storing data and you will find them elsewhere when programming in R. A typical data frame of experimental data contains individual observations in rows and variables in columns.
 
-We can see the shape, or [dimensions]({{ page.root }}/reference/#dimensions), of the data frame with the function `dim`:
+We can see the shape, or [dimensions]({{ page.root }}/reference/#dimensions-of-an-array), of the data frame with the function `dim`:
 
 ```{r}
 dim(dat)

--- a/_episodes_rmd/05-cmdline.Rmd
+++ b/_episodes_rmd/05-cmdline.Rmd
@@ -52,7 +52,7 @@ $ Rscript readings.R --max data/inflammation-*.csv
 
 Our overall requirements are:
 
-1. If no filename is given on the command line, read data from [standard input]({{ page.root }}/reference/#standard-input).
+1. If no filename is given on the command line, read data from [standard input]({{ page.root }}/reference/#standard-input-stdin).
 2. If one or more filenames are given, read data from them and report statistics for each file separately.
 3. Use the `--min`, `--mean`, or `--max` flag to determine what statistic to print.
 
@@ -92,7 +92,7 @@ cat print-args.R
 
 The function `commandArgs` extracts all the command line arguments and returns them as a vector.
 The function `cat`, similar to the `cat` of the Unix Shell, outputs the contents of the variable.
-Since we did not specify a filename for writing, `cat` sends the output to [standard output]({{ page.root }}/reference/#standard-output-(stdout)),
+Since we did not specify a filename for writing, `cat` sends the output to [standard output]({{ page.root }}/reference/#standard-output-stdout),
 which we can then pipe to other Unix functions.
 Because we set the argument `sep` to `"\n"`, which is the symbol to start a new line, each element of the vector is printed on its own line.
 Let's see what happens when we run this program in the Unix Shell:

--- a/_episodes_rmd/11-supp-read-write-csv.Rmd
+++ b/_episodes_rmd/11-supp-read-write-csv.Rmd
@@ -21,7 +21,7 @@ source('../bin/chunk-options.R')
 
 The most common way that scientists store data is in Excel spreadsheets.
 While there are R packages designed to access data from Excel spreadsheets (e.g., gdata, RODBC, XLConnect, xlsx, RExcel),
-users often find it easier to save their spreadsheets in [comma-separated values]({{ page.root }}/reference/#comma-separated-values-(csv)) files (CSV)
+users often find it easier to save their spreadsheets in [comma-separated values]({{ page.root }}/reference/#comma-separated-values-csv) files (CSV)
 and then use R's built in functionality to read and manipulate the data.
 In this short lesson, we'll learn how to read data from a .csv and write to a new .csv,
 and explore the [arguments]({{ page.root }}/reference/#argument) that allow you read and write the data correctly for your needs.

--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ and to use that language *well*.
 
 We are studying inflammation in patients who have been given a new treatment for arthritis,
 and need to analyze the first dozen data sets of their daily inflammation.
-The data sets are stored in [comma-separated values]({{ page.root }}/reference/#comma-separated-values) (CSV) format:
+The data sets are stored in [comma-separated values]({{ page.root }}/reference/#comma-separated-values-csv) (CSV) format:
 each row holds information for a single patient,
 and the columns represent successive days.
 The first few rows of our first file look like this:

--- a/reference.md
+++ b/reference.md
@@ -174,10 +174,10 @@ stack frame
 :   A data structure that provides storage for a function's local variables. Each time a function is called, a new stack frame is created and put on the top of the [call stack](#call-stack). When the function returns, the stack frame is discarded.
 
 standard input (stdin)
-:   A process's default input stream. In interactive command-line applications, it is typically connected to the keyboard; in a [pipe](#pipe), it receives data from the [standard output](#standard-output) of the preceding process.
+:   A process's default input stream. In interactive command-line applications, it is typically connected to the keyboard; in a [pipe](#pipe), it receives data from the [standard output](#standard-output-stdout) of the preceding process.
 
 standard output (stdout)
-:   A process's default output stream. In interactive command-line applications, data sent to standard output is displayed on the screen; in a [pipe](#pipe), it is passed to the [standard input](#standard-input) of the next process.
+:   A process's default output stream. In interactive command-line applications, data sent to standard output is displayed on the screen; in a [pipe](#pipe), it is passed to the [standard input](#standard-input-stdin) of the next process.
 
 string
 :   Short for "character string", a sequence of zero or more characters.


### PR DESCRIPTION
As I mentioned in https://github.com/swcarpentry/styles/pull/129#discussion_r101947877, some of the anchor links pointing to reference.md are broken. Following the merge of https://github.com/github/pages-gem/pull/400, Github now uses kramdown version 1.13.2. It seems that kramdown will remove any parenthesis present in dt titles.

Additionally, none of the anchor links on http://swcarpentry.github.io/r-novice-inflammation/ work currently, as it was last built at Mon, 06 Feb 2017 23:31:25 GMT, prior the the merge of https://github.com/github/pages-gem/pull/400. Any small commit to the gh-pages branch will trigger a rebuild

If you'd like to test this commit, feel free to use https://neon-ninja.github.io/r-novice-inflammation/reference/#comma-separated-values-csv