### PR TITLE
Update 01-starting-with-data.md

### DIFF
--- a/_episodes/01-starting-with-data.md
+++ b/_episodes/01-starting-with-data.md
@@ -755,10 +755,11 @@ We'll learn why this is so in the next lesson.
 >
 > > ## Solution
 > > ~~~
-> > whichPatients <- seq(2,40,2)
-> > whichDays <- c(1:5)
+> > whichPatients <- seq(2,60,2)  # i.e., which rows
+> > whichDays <- c(1:5)           # i.e., which columns
 > > dat2 <- dat
-> > dat2[whichDays, whichPatients] <- dat2[whichDays, whichPatients]/2
+> > dim(dat2[whichPatients, whichDays]) # check the size of your subset: returns `30 5`, that is 30 [rows=patients] by 5 [columns=days]
+> > dat2[whichPatients, whichDays] <- dat2[whichPatients, whichDays]/2
 > > (dat2)
 > > ~~~
 > > {: .r}


### PR DESCRIPTION
## Amend solution for Slicing and Re-Assignment

The exercise presents data for 60 patients (i.e., rows) over 40 days (i.e., columns). Modify `to` argument of `seq` function to number of rows, and transpose the indices in the subset `[` function.

The current solution operates on a subset of the even-numbered days for patients 1 through 5, rather than the even-numbered patients for days 1 through 5.

From Extract.data.frame {base} in the R Documentation, s.v. 'Details':
> When `[` and `[[` are used with two indices (`x[i, j]` and `x[[i, j]]`) they act like indexing a matrix: `[[` can only be used to select one element. Note that for each selected column, `xj` say, typically (if it is not matrix-like), the resulting column will be `xj[i]`, and hence rely on the corresponding `[` method, see the examples section.

