### PR TITLE
Remove words 'easy', 'simple', and 'intuitive' (Issue  #273)

### DIFF
--- a/_episodes/01-starting-with-data.md
+++ b/_episodes/01-starting-with-data.md
@@ -7,7 +7,7 @@ questions:
 - "How do I assign variables?"
 - "What is a data frame?"
 - "How do I access subsets of a data frame?"
-- "How do I calculate simple statistics like mean and median?"
+- "How do I calculate summary statistics like mean and median?"
 - "Where can I get help?"
 - "How can I plot my data?"
 objectives:
@@ -15,7 +15,7 @@ objectives:
 - "Assign values to variables."
 - "Select individual values and subsections from data."
 - "Perform operations on a data frame of data."
-- "Display simple graphs."
+- "Display scatterplot graphs."
 keypoints:
 - "Use `variable <- value` to assign a value to a variable in order to record it in memory."
 - "Objects are created on demand whenever a value is assigned to them."
@@ -24,9 +24,9 @@ keypoints:
 - "Use `from:to` to specify a sequence that includes the indices from `from` to `to`."
 - "All the indexing and subsetting that works on data frames also works on vectors."
 - "Use `#` to add comments to programs."
-- "Use `mean`, `max`, `min` and `sd` to calculate simple statistics."
+- "Use `mean`, `max`, `min` and `sd` to calculate summary statistics."
 - "Use `apply` to calculate statistics across the rows or columns of a data frame."
-- "Use `plot` to create simple visualizations."
+- "Use `plot` to create scatterplot visualizations."
 ---
 
 

--- a/_episodes/02-func-R.md
+++ b/_episodes/02-func-R.md
@@ -25,7 +25,7 @@ keypoints:
 
 
 
-If we only had one data set to analyze, it would probably be faster to load the file into a spreadsheet and use that to plot some simple statistics.
+If we only had one data set to analyze, it would probably be faster to load the file into a spreadsheet and use that to plot some statistics.
 But we have twelve files to check, and may have more in the future.
 In this lesson, we'll learn how to write a function so that we can repeat several operations with a single command.
 
@@ -94,7 +94,7 @@ We've successfully called the function that we defined, and we have access to th
 
 ### Composing Functions
 
-Now that we've seen how to turn Fahrenheit into Kelvin, it's easy to turn Kelvin into Celsius:
+Now that we've seen how to turn Fahrenheit into Kelvin, we can write a function to turn Kelvin into Celsius:
 
 
 ~~~
@@ -267,7 +267,7 @@ center <- function(data, desired) {
 
 We could test this on our actual data, but since we don't know what the values ought to be, it will be hard to tell if the result was correct.
 Instead, let's create a vector of 0s and then center that around 3.
-This will make it simple to see if our function is working as expected:
+This will give us an indication if our function is working as expected:
 
 
 ~~~
@@ -314,7 +314,7 @@ head(centered)
 ~~~
 {: .output}
 
-It's hard to tell from the default output whether the result is correct, but there are a few simple tests that will reassure us:
+It's hard to tell from the default output whether the result is correct, but we can run some tests to reassure ourselves:
 
 
 ~~~

--- a/_episodes/03-loops-R.md
+++ b/_episodes/03-loops-R.md
@@ -7,10 +7,10 @@ questions:
 - "How do I write a `for` loop?"
 objectives:
 - "Explain what a `for` loop does."
-- "Correctly write `for` loops to repeat simple calculations."
+- "Correctly write `for` loops to repeat calculations."
 - "Trace changes to a loop variable as the loop runs."
 - "Trace changes to other variables as they are updated by a `for` loop."
-- "Use a function to get a list of filenames that match a simple pattern."
+- "Use a function to get a list of filenames that contain specific words."
 - "Use a `for` loop to process multiple files."
 keypoints:
 - "Use `for (variable in collection)` to process the elements of a collection one at a time."
@@ -566,7 +566,7 @@ Sure enough, the maxima of these data sets show exactly the same ramp as the fir
 
 > ## Other Ways to Do It
 >
-> In this lesson we saw how to use a simple `for` loop to repeat an operation.
+> In this lesson we saw how to use a `for` loop to repeat an operation.
 > As you progress with R, you will learn that there are multiple ways to
 > accomplish this. Sometimes the choice of one method over another is more a
 > matter of personal style, but other times it can have consequences for the

--- a/_episodes/04-cond.md
+++ b/_episodes/04-cond.md
@@ -167,7 +167,7 @@ if (num > 100) {
 {: .r}
 
 We can also chain several tests together when there are more than two options.
-This makes it simple to write a function that returns the sign of a number:
+This means that we can write a function that returns the sign of a number as:
 
 
 ~~~

--- a/_episodes/05-cmdline.md
+++ b/_episodes/05-cmdline.md
@@ -243,7 +243,7 @@ main <- function() {
 
 
 This function gets the name of the file to process from the first element returned by `commandArgs`.
-Here's a simple test to run from the Unix Shell:
+Here's an example to run from the Unix Shell:
 
 
 ~~~
@@ -341,7 +341,7 @@ Rscript readings-02.R data/inflammation-01.csv
 ~~~
 {: .output}
 
-> ## A Simple Command-Line Program
+> ## A Short Command-Line Program
 >
 > 1. Write a command-line program that does addition and subtraction.
 >
@@ -524,7 +524,7 @@ Rscript readings-02.R data/small-01.csv
 {: .output}
 
 Using small data files as input also allows us to check our results more easily: here, for example, we can see that our program is calculating the mean correctly for each line, whereas we were really taking it on faith before.
-This is yet another rule of programming: test the simple things first.
+This is yet another rule of programming: test small things first, before moving on to larger ones.
 
 We want our program to process each file separately, so we need a loop that executes once for each filename.
 If we specify the files on the command line, the filenames will be returned by `commandArgs(trailingOnly = TRUE)`.

--- a/_episodes/06-best-practices-R.md
+++ b/_episodes/06-best-practices-R.md
@@ -98,7 +98,7 @@ It is also worth considering what the working directory is. If the working direc
 
 ### Identify and segregate distinct components in your code
 
-It's easy to annotate and mark your code using `#` or `#-` to set off sections of your code and to make finding specific parts of your code easier. For example, it's often helpful when writing code to separate the  if you create only one or a few custom functions in your script, put them toward the top of your code. If you have written many functions, put them all in their own .R file and then `source` those files. `source` will define all of these functions so that your code can make use of them as needed. 
+It's helpful to annotate and mark your code using `#` or `#-` to set off sections of your code and to make finding specific parts of your code easier. For example, if you create only a few custom functions in your script, you can put them toward the top of your code both so that you can find them later and they can be used anywhere in the script (in case you realise they are useful in an earlier part too). If you have written many functions, put them all in their own .R file and then `source` those files. `source` will define all of these functions so that your code can make use of them as needed. 
 
 
 

--- a/_episodes/07-knitr-R.md
+++ b/_episodes/07-knitr-R.md
@@ -20,7 +20,7 @@ keypoints:
 
 `knitr` is an R package that allows you to organize your notes, code, and results in a single document. It's a great tool for "literate programming" -- the idea that your code should be readable by humans as well as computers! It also keeps your writing and results together, so if you collect some new data or change how you clean the data, you just have to re-compile the document and you're up to date!
 
-You write `knitr` documents in a simple plain text-like format called markdown, which allows you to format text using intuitive notation, so that you can focus on the content you're writing. But you still get a well-formatted document out. In fact, you can turn your plain text (and R code and results) into an html file or, if you have an installation of LaTeX and Pandoc on your machine, a pdf, or even a Word document (if you must!).
+You write `knitr` documents in a plain text-like format called markdown, which allows you to format text using a well documented notation, so that you can focus on the content you're writing. But you still get a well-formatted document out. In fact, you can turn your plain text (and R code and results) into an html file or, if you have an installation of LaTeX and Pandoc on your machine, a pdf, or even a Word document (if you must!).
 
 To get started, install the `knitr` package.
 

--- a/_episodes/08-making-packages-R.md
+++ b/_episodes/08-making-packages-R.md
@@ -7,7 +7,7 @@ questions:
 - "How do I make my own packages?"
 objectives:
 - "Describe the required structure of R packages."
-- "Create the required structure of a simple R package."
+- "Create the required structure of a minimal R package."
 - "Write documentation comments that can be automatically compiled to R's native help and documentation format."
 
 keypoints:
@@ -89,7 +89,7 @@ fahr_to_celsius <- function(temp) {
 ~~~
 {: .r}
 
-We will use the `devtools` and `roxygen2` packages, which make creating packages in R relatively simple.
+We will use the `devtools` and `roxygen2` packages, which automate some of the steps in creating R packages.
 First, install the `devtools` package, which will allow you to install the `roxygen2` package from GitHub ([code][]).
 
 [code]: https://github.com/klutometis/roxygen
@@ -104,7 +104,7 @@ library("roxygen2")
 {: .r}
 
 Set your working directory, and then use the `create` function to start making your package.
-Keep the name simple and unique.
+Keep the name short and unique.
   - package_to_convert_temperatures_between_kelvin_fahrenheit_and_celsius (BAD)
   - tempConvert (GOOD)
 
@@ -215,5 +215,5 @@ kelvin_to_celsius(273.15)
 > ## Creating a Package for Distribution
 >
 > 1. Create some new functions for your tempConvert package to convert from Kelvin to Fahrenheit or from Celsius to Kelvin or Fahrenheit.
-> 2. Create a package for our `analyze` function so that it will be easy to load when more data arrives.
+> 2. Create a package for our `analyze` function so that it will be can be reloaded or shared when more data arrives.
 {: .challenge}

--- a/_episodes/08-making-packages-R.md
+++ b/_episodes/08-making-packages-R.md
@@ -215,5 +215,5 @@ kelvin_to_celsius(273.15)
 > ## Creating a Package for Distribution
 >
 > 1. Create some new functions for your tempConvert package to convert from Kelvin to Fahrenheit or from Celsius to Kelvin or Fahrenheit.
-> 2. Create a package for our `analyze` function so that it will be can be reloaded or shared when more data arrives.
+> 2. Create a package for our `analyze` function so that it can be reloaded or shared when more data arrives.
 {: .challenge}

--- a/_episodes/12-supp-factors.md
+++ b/_episodes/12-supp-factors.md
@@ -151,7 +151,7 @@ Levels: low < medium < high
 {: .output}
 
 In R's memory, these factors are represented by numbers (1, 2, 3). They are
-better than using simple integer labels because factors are self describing:
+better than using integer labels because factors are self describing:
 `"low"`, `"medium"`, and `"high"`" is more descriptive than `1`, `2`, `3`. Which
 is low?  You wouldn't be able to tell with just integer data. Factors have this
 information built in. It is particularly helpful when there are many levels

--- a/_episodes/15-supp-loops-in-depth.md
+++ b/_episodes/15-supp-loops-in-depth.md
@@ -253,7 +253,7 @@ system.time(avg3 <- analyze3(filenames))
 ~~~
 {: .output}
 
-In this simple example there is little difference in the compute time of `analyze2` and `analyze3`.
+In this small example there is little difference in the compute time of `analyze2` and `analyze3`.
 This is because we are only iterating over 12 files and hence we only incur 12 copy/grow operations.
 If we were doing this over more files or the data objects we were growing were larger, the penalty for copying/growing would be much larger.
 


### PR DESCRIPTION
I have edited the text to remove references to the words:
 * Easy
 * Simple
 * Intuitive

as these words are discouraged in the instructor training. This is following on from Issue #273 which brought attention to this. 