### PR TITLE
guess missing word

### DIFF
--- a/_episodes_rmd/06-best-practices-R.Rmd
+++ b/_episodes_rmd/06-best-practices-R.Rmd
@@ -92,7 +92,7 @@ It is also worth considering what the working directory is. If the working direc
 
 ### Identify and segregate distinct components in your code
 
-It's easy to annotate and mark your code using `#` or `#-` to set off sections of your code and to make finding specific parts of your code easier. For example, it's often helpful when writing code to separate the  if you create only one or a few custom functions in your script, put them toward the top of your code. If you have written many functions, put them all in their own .R file and then `source` those files. `source` will define all of these functions so that your code can make use of them as needed. 
+It's easy to annotate and mark your code using `#` or `#-` to set off sections of your code and to make finding specific parts of your code easier. For example, it's often helpful when writing code to separate the function definitions. If you create only one or a few custom functions in your script, put them toward the top of your code. If you have written many functions, put them all in their own .R file and then `source` those files. `source` will define all of these functions so that your code can make use of them as needed. 
 
 
 ```{r source_ex, eval=FALSE}


### PR DESCRIPTION
Dear @CreRecombinase,

there [was a gap behind "code to separate the"](https://github.com/swcarpentry/r-novice-inflammation/blame/gh-pages/_episodes_rmd/06-best-practices-R.Rmd#L95). Did you maybe mean "function definitions"?

Kind regards, and all the best for 2018 :-)