### PR TITLE
follow-up to PR #297: clarify temperatures

### DIFF
--- a/_episodes/02-func-R.md
+++ b/_episodes/02-func-R.md
@@ -31,18 +31,18 @@ In this lesson, we'll learn how to write a function so that we can repeat severa
 
 ### Defining a Function
 
-Let's start by defining a function `fahr_to_kelvin` that converts temperatures from Fahrenheit to Kelvin:
+Let's start by defining a function `fahrenheit_to_kelvin` that converts temperatures from Fahrenheit to Kelvin:
 
 
 ~~~
-fahr_to_kelvin <- function(temp_F) {
+fahrenheit_to_kelvin <- function(temp_F) {
   temp_K <- ((temp_F - 32) * (5 / 9)) + 273.15
   return(temp_K)
 }
 ~~~
 {: .r}
 
-We define `fahr_to_kelvin` by assigning it to the output of `function`.
+We define `fahrenheit_to_kelvin` by assigning it to the output of `function`.
 The list of argument names are contained within parentheses.
 Next, the [body]({{ page.root }}/reference/#function-body) of the function--the statements that are executed when it runs--is contained within curly braces (`{}`).
 The statements in the body are indented by two spaces, which makes the code easier to read but does not affect how the code operates.
@@ -64,7 +64,7 @@ Calling our own function is no different from calling any other function:
 
 ~~~
 # freezing point of water
-fahr_to_kelvin(32)
+fahrenheit_to_kelvin(32)
 ~~~
 {: .r}
 
@@ -79,7 +79,7 @@ fahr_to_kelvin(32)
 
 ~~~
 # boiling point of water
-fahr_to_kelvin(212)
+fahrenheit_to_kelvin(212)
 ~~~
 {: .r}
 
@@ -121,14 +121,14 @@ Instead, we can [compose]({{ page.root }}/reference/#function-composition) the t
 
 
 ~~~
-fahr_to_celsius <- function(temp_F) {
-  temp_K <- fahr_to_kelvin(temp_F)
+fahrenheit_to_celsius <- function(temp_F) {
+  temp_K <- fahrenheit_to_kelvin(temp_F)
   temp_C <- kelvin_to_celsius(temp_K)
   return(temp_C)
 }
 
 # freezing point of water in Celsius
-fahr_to_celsius(32.0)
+fahrenheit_to_celsius(32.0)
 ~~~
 {: .r}
 
@@ -145,7 +145,7 @@ Real-life functions will usually be larger than the ones shown here--typically h
 
 > ## Chaining Functions
 >
-> This example showed the output of `fahr_to_kelvin` assigned to `temp_K`, which
+> This example showed the output of `fahrenheit_to_kelvin` assigned to `temp_K`, which
 > is then passed to `kelvin_to_celsius` to get the final result. It is also possible
 > to perform this calculation in one line of code, by "chaining" functions
 > together, like so:
@@ -153,7 +153,7 @@ Real-life functions will usually be larger than the ones shown here--typically h
 > 
 > ~~~
 > # freezing point of water in Celsius
-> kelvin_to_celsius(fahr_to_kelvin(32.0))
+> kelvin_to_celsius(fahrenheit_to_kelvin(32.0))
 > ~~~
 > {: .r}
 > 

--- a/_episodes/02-func-R.md
+++ b/_episodes/02-func-R.md
@@ -35,8 +35,8 @@ Let's start by defining a function `fahr_to_kelvin` that converts temperatures f
 
 
 ~~~
-fahr_to_kelvin = function(temp_fahr){
-  temp_kelv = ((temp_fahr - 32)*(5/9))+273.15
+fahr_to_kelvin <- function(temp_fahr){
+  temp_kelv <- ((temp_fahr - 32)*(5/9))+273.15
   return(temp_kelv)
 }
 ~~~
@@ -98,8 +98,8 @@ Now that we've seen how to turn Fahrenheit into Kelvin, it's easy to turn Kelvin
 
 
 ~~~
-kelvin_to_celsius = function(temp_kelv){
-  temp_cels = temp_kelv - 273.15
+kelvin_to_celsius <- function(temp_kelv){
+  temp_cels <- temp_kelv - 273.15
   return(temp_cels)
 }
 
@@ -121,9 +121,9 @@ Instead, we can [compose]({{ page.root }}/reference/#function-composition) the t
 
 
 ~~~
-fahr_to_celsius = function(temp_fahr){
-  temp_kelv = fahr_to_kelvin(temp_fahr)
-  temp_cels = kelvin_to_celsius(temp_kelv)
+fahr_to_celsius <- function(temp_fahr){
+  temp_kelv <- fahr_to_kelvin(temp_fahr)
+  temp_cels <- kelvin_to_celsius(temp_kelv)
   return(temp_cels)
 }
 

--- a/_episodes/02-func-R.md
+++ b/_episodes/02-func-R.md
@@ -35,9 +35,9 @@ Let's start by defining a function `fahr_to_kelvin` that converts temperatures f
 
 
 ~~~
-fahr_to_kelvin <- function(temp_fahr){
-  temp_kelv <- ((temp_fahr - 32)*(5/9))+273.15
-  return(temp_kelv)
+fahr_to_kelvin <- function(temp_F) {
+  temp_K <- ((temp_F - 32) * (5 / 9)) + 273.15
+  return(temp_K)
 }
 ~~~
 {: .r}
@@ -98,9 +98,9 @@ Now that we've seen how to turn Fahrenheit into Kelvin, it's easy to turn Kelvin
 
 
 ~~~
-kelvin_to_celsius <- function(temp_kelv){
-  temp_cels <- temp_kelv - 273.15
-  return(temp_cels)
+kelvin_to_celsius <- function(temp_K) {
+  temp_C <- temp_K - 273.15
+  return(temp_C)
 }
 
 #absolute zero in Celsius
@@ -121,10 +121,10 @@ Instead, we can [compose]({{ page.root }}/reference/#function-composition) the t
 
 
 ~~~
-fahr_to_celsius <- function(temp_fahr){
-  temp_kelv <- fahr_to_kelvin(temp_fahr)
-  temp_cels <- kelvin_to_celsius(temp_kelv)
-  return(temp_cels)
+fahr_to_celsius <- function(temp_F) {
+  temp_K <- fahr_to_kelvin(temp_F)
+  temp_C <- kelvin_to_celsius(temp_K)
+  return(temp_C)
 }
 
 # freezing point of water in Celsius
@@ -145,7 +145,7 @@ Real-life functions will usually be larger than the ones shown here--typically h
 
 > ## Chaining Functions
 >
-> This example showed the output of `fahr_to_kelvin` assigned to `temp_k`, which
+> This example showed the output of `fahr_to_kelvin` assigned to `temp_K`, which
 > is then passed to `kelvin_to_celsius` to get the final result. It is also possible
 > to perform this calculation in one line of code, by "chaining" functions
 > together, like so:

--- a/_episodes/08-making-packages-R.md
+++ b/_episodes/08-making-packages-R.md
@@ -60,31 +60,31 @@ Let's turn our temperature conversion functions into an R package.
 
 
 ~~~
-fahr_to_kelvin <- function(temp) {
+fahr_to_kelvin <- function(temp_F) {
     #Converts Fahrenheit to Kelvin
-    kelvin <- ((temp - 32) * (5/9)) + 273.15
-    kelvin
+    temp_K <- ((temp_F - 32) * (5/9)) + 273.15
+    temp_K
 }
 ~~~
 {: .r}
 
 
 ~~~
-kelvin_to_celsius <- function(temp) {
+kelvin_to_celsius <- function(temp_K) {
   #Converts Kelvin to Celsius
-  Celsius <- temp - 273.15
-  Celsius
+  temp_C <- temp_K - 273.15
+  temp_C
 }
 ~~~
 {: .r}
 
 
 ~~~
-fahr_to_celsius <- function(temp) {
+fahr_to_celsius <- function(temp_F) {
   #Converts Fahrenheit to Celsius using fahr_to_kelvin() and kelvin_to_celsius()
-  temp_k <- fahr_to_kelvin(temp)
-	result <- kelvin_to_celsius(temp_k)
-  result
+  temp_K <- fahr_to_kelvin(temp_F)
+	temp_C <- kelvin_to_celsius(temp_K)
+  temp_C
 }
 ~~~
 {: .r}
@@ -123,15 +123,15 @@ Place each function into a separate R script and add documentation like this:
 #' Converts Fahrenheit to Kelvin
 #'
 #' This function converts input temperatures in Fahrenheit to Kelvin.
-#' @param temp The temperature in Fahrenheit.
+#' @param temp_F The temperature in Fahrenheit.
 #' @return The temperature in Kelvin.
 #' @export
 #' @examples
 #' fahr_to_kelvin(32)
 
-fahr_to_kelvin <- function(temp) {
-  kelvin <- ((temp - 32) * (5/9)) + 273.15
-  kelvin
+fahr_to_kelvin <- function(temp_F) {
+  temp_K <- ((temp_F - 32) * (5/9)) + 273.15
+  temp_K
 }
 ~~~
 {: .r}

--- a/_episodes/08-making-packages-R.md
+++ b/_episodes/08-making-packages-R.md
@@ -60,7 +60,7 @@ Let's turn our temperature conversion functions into an R package.
 
 
 ~~~
-fahr_to_kelvin <- function(temp_F) {
+fahrenheit_to_kelvin <- function(temp_F) {
     #Converts Fahrenheit to Kelvin
     temp_K <- ((temp_F - 32) * (5/9)) + 273.15
     temp_K
@@ -80,9 +80,9 @@ kelvin_to_celsius <- function(temp_K) {
 
 
 ~~~
-fahr_to_celsius <- function(temp_F) {
-  #Converts Fahrenheit to Celsius using fahr_to_kelvin() and kelvin_to_celsius()
-  temp_K <- fahr_to_kelvin(temp_F)
+fahrenheit_to_celsius <- function(temp_F) {
+  #Converts Fahrenheit to Celsius using fahrenheit_to_kelvin() and kelvin_to_celsius()
+  temp_K <- fahrenheit_to_kelvin(temp_F)
 	temp_C <- kelvin_to_celsius(temp_K)
   temp_C
 }
@@ -127,9 +127,9 @@ Place each function into a separate R script and add documentation like this:
 #' @return The temperature in Kelvin.
 #' @export
 #' @examples
-#' fahr_to_kelvin(32)
+#' fahrenheit_to_kelvin(32)
 
-fahr_to_kelvin <- function(temp_F) {
+fahrenheit_to_kelvin <- function(temp_F) {
   temp_K <- ((temp_F - 32) * (5/9)) + 273.15
   temp_K
 }
@@ -157,7 +157,7 @@ Now, let's load the package and take a look at the documentation.
 setwd("..")
 install("tempConvert")
 
-?fahr_to_kelvin
+?fahrenheit_to_kelvin
 ~~~
 {: .r}
 
@@ -173,7 +173,7 @@ Now that our package is loaded, let's try out some of the functions.
 
 
 ~~~
-fahr_to_celsius(32)
+fahrenheit_to_celsius(32)
 ~~~
 {: .r}
 
@@ -187,7 +187,7 @@ fahr_to_celsius(32)
 
 
 ~~~
-fahr_to_kelvin(212)
+fahrenheit_to_kelvin(212)
 ~~~
 {: .r}
 

--- a/_episodes/14-supp-call-stack.md
+++ b/_episodes/14-supp-call-stack.md
@@ -18,14 +18,14 @@ keypoints:
 
 ### The Call Stack
 
-Let's take a closer look at what happens when we call `fahr_to_celsius(32)`.
+Let's take a closer look at what happens when we call `fahrenheit_to_celsius(32)`.
 To make things clearer,
 we'll start by putting the initial value 32 in a variable and store the final result in one as well:
 
 
 ~~~
 original <- 32
-final <- fahr_to_celsius(original)
+final <- fahrenheit_to_celsius(original)
 ~~~
 {: .r}
 
@@ -33,20 +33,20 @@ The diagram below shows what memory looks like after the first line has been exe
 
 <img src="../fig/python-call-stack-01.svg" alt="Call Stack (Initial State)" />
 
-When we call `fahr_to_celsius`, R *doesn't* create the variable `temp` right away.
-Instead, it creates something called a [stack frame]({{ page.root }}/reference/#stack-frame) to keep track of the variables defined by `fahr_to_kelvin`.
+When we call `fahrenheit_to_celsius`, R *doesn't* create the variable `temp` right away.
+Instead, it creates something called a [stack frame]({{ page.root }}/reference/#stack-frame) to keep track of the variables defined by `fahrenheit_to_kelvin`.
 Initially, this stack frame only holds the value of `temp`:
 
 <img src="../fig/python-call-stack-02.svg" alt="Call Stack Immediately After First Function Call" />
 
-When we call `fahr_to_kelvin` inside `fahr_to_celsius`, R creates another stack frame to hold `fahr_to_kelvin`'s variables:
+When we call `fahrenheit_to_kelvin` inside `fahrenheit_to_celsius`, R creates another stack frame to hold `fahrenheit_to_kelvin`'s variables:
 
 <img src="../fig/python-call-stack-03.svg" alt="Call Stack During First Nested Function Call" />
 
-It does this because there are now two variables in play called `temp`: the argument to `fahr_to_celsius`, and the argument to `fahr_to_kelvin`.
+It does this because there are now two variables in play called `temp`: the argument to `fahrenheit_to_celsius`, and the argument to `fahrenheit_to_kelvin`.
 Having two variables with the same name in the same part of the program would be ambiguous, so R (and every other modern programming language) creates a new stack frame for each function call to keep that function's variables separate from those defined by other functions.
 
-When the call to `fahr_to_kelvin` returns a value, R throws away `fahr_to_kelvin`'s stack frame and creates a new variable in the stack frame for `fahr_to_celsius` to hold the temperature in Kelvin:
+When the call to `fahrenheit_to_kelvin` returns a value, R throws away `fahrenheit_to_kelvin`'s stack frame and creates a new variable in the stack frame for `fahrenheit_to_celsius` to hold the temperature in Kelvin:
 
 <img src="../fig/python-call-stack-04.svg" alt="Call Stack After Return From First Nested Function Call" />
 
@@ -55,11 +55,11 @@ It then calls `kelvin_to_celsius`, which means it creates a stack frame to hold 
 <img src="../fig/python-call-stack-05.svg" alt="Call Stack During Call to Second Nested Function" />
 
 Once again, R throws away that stack frame when `kelvin_to_celsius` is done
-and creates the variable `result` in the stack frame for `fahr_to_celsius`:
+and creates the variable `result` in the stack frame for `fahrenheit_to_celsius`:
 
 <img src="../fig/python-call-stack-06.svg" alt="Call Stack After Second Nested Function Returns" />
 
-Finally, when `fahr_to_celsius` is done, R throws away *its* stack frame and puts its result in a new variable called `final` that lives in the stack frame we started with:
+Finally, when `fahrenheit_to_celsius` is done, R throws away *its* stack frame and puts its result in a new variable called `final` that lives in the stack frame we started with:
 
 <img src="../fig/python-call-stack-07.svg" alt="Call Stack After All Functions Have Finished" />
 

--- a/_episodes_rmd/02-func-R.Rmd
+++ b/_episodes_rmd/02-func-R.Rmd
@@ -37,9 +37,9 @@ In this lesson, we'll learn how to write a function so that we can repeat severa
 Let's start by defining a function `fahr_to_kelvin` that converts temperatures from Fahrenheit to Kelvin:
 
 ```{r}
-fahr_to_kelvin <- function(temp) {
-  kelvin <- ((temp - 32) * (5 / 9)) + 273.15
-  return(kelvin)
+fahr_to_kelvin <- function(temp_F) {
+  temp_K <- ((temp_F - 32) * (5 / 9)) + 273.15
+  return(temp_K)
 }
 ```
 
@@ -76,9 +76,9 @@ We've successfully called the function that we defined, and we have access to th
 Now that we've seen how to turn Fahrenheit into Kelvin, it's easy to turn Kelvin into Celsius:
 
 ```{r}
-kelvin_to_celsius <- function(temp) {
-  celsius <- temp - 273.15
-  return(celsius)
+kelvin_to_celsius <- function(temp_K) {
+  temp_C <- temp_K - 273.15
+  return(temp_C)
 }
 
 #absolute zero in Celsius
@@ -90,10 +90,10 @@ We could write out the formula, but we don't need to.
 Instead, we can [compose]({{ page.root }}/reference/#function-composition) the two functions we have already created:
 
 ```{r}
-fahr_to_celsius <- function(temp) {
-  temp_k <- fahr_to_kelvin(temp)
-  result <- kelvin_to_celsius(temp_k)
-  return(result)
+fahr_to_celsius <- function(temp_F) {
+  temp_K <- fahr_to_kelvin(temp_F)
+  temp_C <- kelvin_to_celsius(temp_K)
+  return(temp_C)
 }
 
 # freezing point of water in Celsius
@@ -106,7 +106,7 @@ Real-life functions will usually be larger than the ones shown here--typically h
 
 > ## Chaining Functions
 >
-> This example showed the output of `fahr_to_kelvin` assigned to `temp_k`, which
+> This example showed the output of `fahr_to_kelvin` assigned to `temp_K`, which
 > is then passed to `kelvin_to_celsius` to get the final result. It is also possible
 > to perform this calculation in one line of code, by "chaining" functions
 > together, like so:

--- a/_episodes_rmd/02-func-R.Rmd
+++ b/_episodes_rmd/02-func-R.Rmd
@@ -34,16 +34,16 @@ In this lesson, we'll learn how to write a function so that we can repeat severa
 
 ### Defining a Function
 
-Let's start by defining a function `fahr_to_kelvin` that converts temperatures from Fahrenheit to Kelvin:
+Let's start by defining a function `fahrenheit_to_kelvin` that converts temperatures from Fahrenheit to Kelvin:
 
 ```{r}
-fahr_to_kelvin <- function(temp_F) {
+fahrenheit_to_kelvin <- function(temp_F) {
   temp_K <- ((temp_F - 32) * (5 / 9)) + 273.15
   return(temp_K)
 }
 ```
 
-We define `fahr_to_kelvin` by assigning it to the output of `function`.
+We define `fahrenheit_to_kelvin` by assigning it to the output of `function`.
 The list of argument names are contained within parentheses.
 Next, the [body]({{ page.root }}/reference/#function-body) of the function--the statements that are executed when it runs--is contained within curly braces (`{}`).
 The statements in the body are indented by two spaces, which makes the code easier to read but does not affect how the code operates.
@@ -64,9 +64,9 @@ Calling our own function is no different from calling any other function:
 
 ```{r}
 # freezing point of water
-fahr_to_kelvin(32)
+fahrenheit_to_kelvin(32)
 # boiling point of water
-fahr_to_kelvin(212)
+fahrenheit_to_kelvin(212)
 ```
 
 We've successfully called the function that we defined, and we have access to the value that we returned.
@@ -90,14 +90,14 @@ We could write out the formula, but we don't need to.
 Instead, we can [compose]({{ page.root }}/reference/#function-composition) the two functions we have already created:
 
 ```{r}
-fahr_to_celsius <- function(temp_F) {
-  temp_K <- fahr_to_kelvin(temp_F)
+fahrenheit_to_celsius <- function(temp_F) {
+  temp_K <- fahrenheit_to_kelvin(temp_F)
   temp_C <- kelvin_to_celsius(temp_K)
   return(temp_C)
 }
 
 # freezing point of water in Celsius
-fahr_to_celsius(32.0)
+fahrenheit_to_celsius(32.0)
 ```
 
 This is our first taste of how larger programs are built: we define basic
@@ -106,14 +106,14 @@ Real-life functions will usually be larger than the ones shown here--typically h
 
 > ## Chaining Functions
 >
-> This example showed the output of `fahr_to_kelvin` assigned to `temp_K`, which
+> This example showed the output of `fahrenheit_to_kelvin` assigned to `temp_K`, which
 > is then passed to `kelvin_to_celsius` to get the final result. It is also possible
 > to perform this calculation in one line of code, by "chaining" functions
 > together, like so:
 >
 > ```{r chained-example}
 > # freezing point of water in Celsius
-> kelvin_to_celsius(fahr_to_kelvin(32.0))
+> kelvin_to_celsius(fahrenheit_to_kelvin(32.0))
 > ```
 {: .callout}
 

--- a/_episodes_rmd/08-making-packages-R.Rmd
+++ b/_episodes_rmd/08-making-packages-R.Rmd
@@ -61,7 +61,7 @@ Suggestion: organize in a logical manner so that you know which file holds which
 Let's turn our temperature conversion functions into an R package.
 
 ```{r}
-fahr_to_kelvin <- function(temp_F) {
+fahrenheit_to_kelvin <- function(temp_F) {
     #Converts Fahrenheit to Kelvin
     temp_K <- ((temp_F - 32) * (5/9)) + 273.15
     temp_K
@@ -77,9 +77,9 @@ kelvin_to_celsius <- function(temp_K) {
 ```
 
 ```{r}
-fahr_to_celsius <- function(temp_F) {
-  #Converts Fahrenheit to Celsius using fahr_to_kelvin() and kelvin_to_celsius()
-  temp_K <- fahr_to_kelvin(temp_F)
+fahrenheit_to_celsius <- function(temp_F) {
+  #Converts Fahrenheit to Celsius using fahrenheit_to_kelvin() and kelvin_to_celsius()
+  temp_K <- fahrenheit_to_kelvin(temp_F)
 	temp_C <- kelvin_to_celsius(temp_K)
   temp_C
 }
@@ -118,9 +118,9 @@ Place each function into a separate R script and add documentation like this:
 #' @return The temperature in Kelvin.
 #' @export
 #' @examples
-#' fahr_to_kelvin(32)
+#' fahrenheit_to_kelvin(32)
 
-fahr_to_kelvin <- function(temp_F) {
+fahrenheit_to_kelvin <- function(temp_F) {
   temp_K <- ((temp_F - 32) * (5/9)) + 273.15
   temp_K
 }
@@ -144,7 +144,7 @@ Now, let's load the package and take a look at the documentation.
 setwd("..")
 install("tempConvert")
 
-?fahr_to_kelvin
+?fahrenheit_to_kelvin
 ```
 
 Notice there is now a tempConvert environment that is the parent environment to the global environment.
@@ -156,8 +156,8 @@ search()
 Now that our package is loaded, let's try out some of the functions.
 
 ```{r}
-fahr_to_celsius(32)
-fahr_to_kelvin(212)
+fahrenheit_to_celsius(32)
+fahrenheit_to_kelvin(212)
 kelvin_to_celsius(273.15)
 ```
 

--- a/_episodes_rmd/08-making-packages-R.Rmd
+++ b/_episodes_rmd/08-making-packages-R.Rmd
@@ -61,27 +61,27 @@ Suggestion: organize in a logical manner so that you know which file holds which
 Let's turn our temperature conversion functions into an R package.
 
 ```{r}
-fahr_to_kelvin <- function(temp) {
+fahr_to_kelvin <- function(temp_F) {
     #Converts Fahrenheit to Kelvin
-    kelvin <- ((temp - 32) * (5/9)) + 273.15
-    kelvin
+    temp_K <- ((temp_F - 32) * (5/9)) + 273.15
+    temp_K
 }
 ```
 
 ```{r}
-kelvin_to_celsius <- function(temp) {
+kelvin_to_celsius <- function(temp_K) {
   #Converts Kelvin to Celsius
-  Celsius <- temp - 273.15
-  Celsius
+  temp_C <- temp_K - 273.15
+  temp_C
 }
 ```
 
 ```{r}
-fahr_to_celsius <- function(temp) {
+fahr_to_celsius <- function(temp_F) {
   #Converts Fahrenheit to Celsius using fahr_to_kelvin() and kelvin_to_celsius()
-  temp_k <- fahr_to_kelvin(temp)
-	result <- kelvin_to_celsius(temp_k)
-  result
+  temp_K <- fahr_to_kelvin(temp_F)
+	temp_C <- kelvin_to_celsius(temp_K)
+  temp_C
 }
 ```
 
@@ -114,15 +114,15 @@ Place each function into a separate R script and add documentation like this:
 #' Converts Fahrenheit to Kelvin
 #'
 #' This function converts input temperatures in Fahrenheit to Kelvin.
-#' @param temp The temperature in Fahrenheit.
+#' @param temp_F The temperature in Fahrenheit.
 #' @return The temperature in Kelvin.
 #' @export
 #' @examples
 #' fahr_to_kelvin(32)
 
-fahr_to_kelvin <- function(temp) {
-  kelvin <- ((temp - 32) * (5/9)) + 273.15
-  kelvin
+fahr_to_kelvin <- function(temp_F) {
+  temp_K <- ((temp_F - 32) * (5/9)) + 273.15
+  temp_K
 }
 ```
 

--- a/_episodes_rmd/14-supp-call-stack.Rmd
+++ b/_episodes_rmd/14-supp-call-stack.Rmd
@@ -20,33 +20,33 @@ source("../bin/chunk-options.R")
 
 ### The Call Stack
 
-Let's take a closer look at what happens when we call `fahr_to_celsius(32)`.
+Let's take a closer look at what happens when we call `fahrenheit_to_celsius(32)`.
 To make things clearer,
 we'll start by putting the initial value 32 in a variable and store the final result in one as well:
 
 ```{r, eval = FALSE}
 original <- 32
-final <- fahr_to_celsius(original)
+final <- fahrenheit_to_celsius(original)
 ```
 
 The diagram below shows what memory looks like after the first line has been executed:
 
 <img src="../fig/python-call-stack-01.svg" alt="Call Stack (Initial State)" />
 
-When we call `fahr_to_celsius`, R *doesn't* create the variable `temp` right away.
-Instead, it creates something called a [stack frame]({{ page.root }}/reference/#stack-frame) to keep track of the variables defined by `fahr_to_kelvin`.
+When we call `fahrenheit_to_celsius`, R *doesn't* create the variable `temp` right away.
+Instead, it creates something called a [stack frame]({{ page.root }}/reference/#stack-frame) to keep track of the variables defined by `fahrenheit_to_kelvin`.
 Initially, this stack frame only holds the value of `temp`:
 
 <img src="../fig/python-call-stack-02.svg" alt="Call Stack Immediately After First Function Call" />
 
-When we call `fahr_to_kelvin` inside `fahr_to_celsius`, R creates another stack frame to hold `fahr_to_kelvin`'s variables:
+When we call `fahrenheit_to_kelvin` inside `fahrenheit_to_celsius`, R creates another stack frame to hold `fahrenheit_to_kelvin`'s variables:
 
 <img src="../fig/python-call-stack-03.svg" alt="Call Stack During First Nested Function Call" />
 
-It does this because there are now two variables in play called `temp`: the argument to `fahr_to_celsius`, and the argument to `fahr_to_kelvin`.
+It does this because there are now two variables in play called `temp`: the argument to `fahrenheit_to_celsius`, and the argument to `fahrenheit_to_kelvin`.
 Having two variables with the same name in the same part of the program would be ambiguous, so R (and every other modern programming language) creates a new stack frame for each function call to keep that function's variables separate from those defined by other functions.
 
-When the call to `fahr_to_kelvin` returns a value, R throws away `fahr_to_kelvin`'s stack frame and creates a new variable in the stack frame for `fahr_to_celsius` to hold the temperature in Kelvin:
+When the call to `fahrenheit_to_kelvin` returns a value, R throws away `fahrenheit_to_kelvin`'s stack frame and creates a new variable in the stack frame for `fahrenheit_to_celsius` to hold the temperature in Kelvin:
 
 <img src="../fig/python-call-stack-04.svg" alt="Call Stack After Return From First Nested Function Call" />
 
@@ -55,11 +55,11 @@ It then calls `kelvin_to_celsius`, which means it creates a stack frame to hold 
 <img src="../fig/python-call-stack-05.svg" alt="Call Stack During Call to Second Nested Function" />
 
 Once again, R throws away that stack frame when `kelvin_to_celsius` is done
-and creates the variable `result` in the stack frame for `fahr_to_celsius`:
+and creates the variable `result` in the stack frame for `fahrenheit_to_celsius`:
 
 <img src="../fig/python-call-stack-06.svg" alt="Call Stack After Second Nested Function Returns" />
 
-Finally, when `fahr_to_celsius` is done, R throws away *its* stack frame and puts its result in a new variable called `final` that lives in the stack frame we started with:
+Finally, when `fahrenheit_to_celsius` is done, R throws away *its* stack frame and puts its result in a new variable called `final` that lives in the stack frame we started with:
 
 <img src="../fig/python-call-stack-07.svg" alt="Call Stack After All Functions Have Finished" />
 


### PR DESCRIPTION
I failed to notice the `=` for assignments in #297, so this:

1. reverts only those, 
1. percolates @colinnavin's smart variable renames into the other source files, and 
1. renames the `fahr_…` functions as discussed. 