### PR TITLE
Edit to command line lesson

### DIFF
--- a/_episodes/05-cmdline.md
+++ b/_episodes/05-cmdline.md
@@ -806,7 +806,7 @@ lines in standard input: 2
 ~~~
 {: .output}
 
-Note that because we did not specify `sep = "\n"` when calling `cat`, the output is written on the same line.
+Note that because we did not specify `sep = "\n"` when calling the first `cat`, the output is written on the same line.
 
 A common mistake is to try to run something that reads from standard input like this:
 

--- a/_episodes_rmd/check.R
+++ b/_episodes_rmd/check.R
@@ -9,8 +9,10 @@ main <- function() {
   args <- commandArgs(trailingOnly = TRUE)
   first_file <- read.csv(args[1], header = FALSE)
   first_dim <- dim(first_file)
-#   num_rows <- dim(args[1])[1]  # nrow(args[1])
-#   num_cols <- dim(args[1])[2]  # ncol(args[1])
+#   num_rows <- dim(first_file)[1]  # nrow(first_file)
+#   num_cols <- dim(first_file)[2]  # ncol(first_file)
+  
+  
   for (filename in args[-1]) {
     new_file <- read.csv(filename, header = FALSE)
     new_dim <- dim(new_file)


### PR DESCRIPTION
Edit suggestion to check.R. The original example code tried to calculate the dimension of the filename to obtain the number of rows and columns. This has been edited to calculating the dimension on the file instead.

Suggested edit to the lesson text under the section 'Handling Standard Input' to clarify that `sep = “\n”` was only present in the second `cat`, so that the text prints on the same line.