### PR TITLE
Hyperlink relevant resources

### DIFF
--- a/_episodes_rmd/06-best-practices-R.Rmd
+++ b/_episodes_rmd/06-best-practices-R.Rmd
@@ -136,7 +136,7 @@ rm(list = ls()) # If you want to delete all the objects in the workspace and sta
 
 8. Collaborate. Grab a buddy and practice "code review". Review is used for preparing experiments and manuscripts; why not use it for code as well? Our code is also a major scientific achievement and the product of lots of hard work!
 
-9. Develop your code using version control and frequent updates! You can find lessons about version control on [software-carpentry.org/lessons](https://software-carpentry.org/lessons/).
+9. Develop your code using version control and frequent updates! You can find lessons about version control on [software-carpentry.org/lessons][lessons].
 
 > ## Best Practice
 >

--- a/_episodes_rmd/06-best-practices-R.Rmd
+++ b/_episodes_rmd/06-best-practices-R.Rmd
@@ -136,7 +136,7 @@ rm(list = ls()) # If you want to delete all the objects in the workspace and sta
 
 8. Collaborate. Grab a buddy and practice "code review". Review is used for preparing experiments and manuscripts; why not use it for code as well? Our code is also a major scientific achievement and the product of lots of hard work!
 
-9. Develop your code using version control and frequent updates!
+9. Develop your code using version control and frequent updates! You can find lessons about version control on [software-carpentry.org/lessons](https://software-carpentry.org/lessons/).
 
 > ## Best Practice
 >

--- a/_episodes_rmd/07-knitr-R.Rmd
+++ b/_episodes_rmd/07-knitr-R.Rmd
@@ -22,7 +22,7 @@ source("../bin/chunk-options.R")
 
 `knitr` is an R package that allows you to organize your notes, code, and results in a single document. It's a great tool for "literate programming" -- the idea that your code should be readable by humans as well as computers! It also keeps your writing and results together, so if you collect some new data or change how you clean the data, you just have to re-compile the document and you're up to date!
 
-You write `knitr` documents in a simple plain text-like format called markdown, which allows you to format text using intuitive notation, so that you can focus on the content you're writing. But you still get a well-formatted document out. In fact, you can turn your plain text (and R code and results) into an html file or, if you have an installation of LaTeX and Pandoc on your machine, a pdf, or even a Word document (if you must!).
+You write `knitr` documents in a simple plain text-like format called markdown, which allows you to format text using intuitive notation, so that you can focus on the content you're writing and generating a well-formatted document when needed. In fact, you can turn your plain text (and R code and results) into an HTML file or, if you have an installation of LaTeX and [Pandoc](https://pandoc.org/) on your machine, a PDF, or even a Word document (if you must!).
 
 To get started, install the `knitr` package.
 

--- a/_episodes_rmd/07-knitr-R.Rmd
+++ b/_episodes_rmd/07-knitr-R.Rmd
@@ -22,7 +22,7 @@ source("../bin/chunk-options.R")
 
 `knitr` is an R package that allows you to organize your notes, code, and results in a single document. It's a great tool for "literate programming" -- the idea that your code should be readable by humans as well as computers! It also keeps your writing and results together, so if you collect some new data or change how you clean the data, you just have to re-compile the document and you're up to date!
 
-You write `knitr` documents in a simple plain text-like format called markdown, which allows you to format text using intuitive notation, so that you can focus on the content you're writing and generating a well-formatted document when needed. In fact, you can turn your plain text (and R code and results) into an HTML file or, if you have an installation of LaTeX and [Pandoc](https://pandoc.org/) on your machine, a PDF, or even a Word document (if you must!).
+You write `knitr` documents in a simple plain text-like format called markdown, which allows you to format text using intuitive notation, so that you can focus on the content you're writing and generating a well-formatted document when needed. In fact, you can turn your plain text (and R code and results) into an HTML file or, if you have an installation of LaTeX and [Pandoc][pandoc] on your machine, a PDF, or even a Word document (if you must!).
 
 To get started, install the `knitr` package.
 

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -14,6 +14,7 @@
 [jekyll-windows]: http://jekyll-windows.juthilo.com/
 [jekyll]: https://jekyllrb.com/
 [jupyter]: https://jupyter.org/
+[lessons]: https://software-carpentry.org/lessons/
 [mit-license]: https://opensource.org/licenses/mit-license.html
 [morea]: https://morea-framework.github.io/
 [numfocus]: https://numfocus.org/


### PR DESCRIPTION
This PR is a work-in-progress and shall add hyperlink occurrences of keywords in the text that exist in the lesson already, or to other carpentry lessons. Not like https://github.com/swcarpentry/lesson-example/issues/163 which discusses adding a new section for useful external resources that the lessons do not currently link to.