### PR TITLE
Introduce regex with digits instead of wildcard

### DIFF
--- a/_episodes_rmd/03-loops-R.Rmd
+++ b/_episodes_rmd/03-loops-R.Rmd
@@ -318,7 +318,13 @@ Let's test out running our `analyze` function by using it on the first three fil
 
 
 ```{r loop-analyze, fig=FALSE}
-filenames <- list.files(path = "data", pattern = "inflammation-[0-9]{2}.csv", full.names = TRUE)
+filenames <- list.files(path = "data", 
+                        pattern = "inflammation-[0-9]{2}.csv", 
+                        # This pattern is a regular expression that matches:
+                        # a) the static part of the filenames,
+                        # b) the variable part (two of the digits 0 to 9), and
+                        # c) the static file type CSV.
+                        full.names = TRUE)
 filenames <- filenames[1:3]
 for (f in filenames) {
   print(f)

--- a/_episodes_rmd/03-loops-R.Rmd
+++ b/_episodes_rmd/03-loops-R.Rmd
@@ -318,7 +318,7 @@ Let's test out running our `analyze` function by using it on the first three fil
 
 
 ```{r loop-analyze, fig=FALSE}
-filenames <- list.files(path = "data", pattern = "inflammation.*csv", full.names = TRUE)
+filenames <- list.files(path = "data", pattern = "inflammation-[0-9]{2}.csv", full.names = TRUE)
 filenames <- filenames[1:3]
 for (f in filenames) {
   print(f)

--- a/_episodes_rmd/03-loops-R.Rmd
+++ b/_episodes_rmd/03-loops-R.Rmd
@@ -318,12 +318,12 @@ Let's test out running our `analyze` function by using it on the first three fil
 
 
 ```{r loop-analyze, fig=FALSE}
-filenames <- list.files(path = "data", 
-                        pattern = "inflammation-[0-9]{2}.csv", 
-                        # This pattern is a regular expression that matches:
-                        # a) the static part of the filenames,
-                        # b) the variable part (two of the digits 0 to 9), and
-                        # c) the static file type CSV.
+filenames <- list.files(path = "data",  
+                        # Now follows a regular expression that matches:
+                        pattern = "inflammation-[0-9]{2}.csv",
+                        #          |            |       "csv": the static file extension of comma-separated values,
+                        #          |           "[0-9]{2}": the variable parts (two of the digits 0 to 9, and
+                        #         "inflammation-": the static part of the filenames
                         full.names = TRUE)
 filenames <- filenames[1:3]
 for (f in filenames) {

--- a/_episodes_rmd/03-loops-R.Rmd
+++ b/_episodes_rmd/03-loops-R.Rmd
@@ -321,9 +321,9 @@ Let's test out running our `analyze` function by using it on the first three fil
 filenames <- list.files(path = "data",  
                         # Now follows a regular expression that matches:
                         pattern = "inflammation-[0-9]{2}.csv",
-                        #          |            |       "csv": the static file extension of comma-separated values,
-                        #          |           "[0-9]{2}": the variable parts (two of the digits 0 to 9, and
-                        #         "inflammation-": the static part of the filenames
+                        #          |            |        the static file extension of comma-separated values,
+                        #          |            the variable parts (two of the digits 0 to 9, and
+                        #          the static part of the filenames
                         full.names = TRUE)
 filenames <- filenames[1:3]
 for (f in filenames) {


### PR DESCRIPTION
[shell-novice/04-pipefilter](https://github.com/swcarpentry/shell-novice/blob/gh-pages/_episodes/04-pipefilter.md#using-wildcards) introduces `.*` as a wildcard for file-names. On the surface, this seems to be the same as in `list.files(… pattern = "…")`, but that needs to be a regular-expression, in which the `.` matches many more characters than the `.` before the file extension in the shell.

Hence, and in order to prepare future learning of REs, I suggest to restrict the RE here to the number sequence that the example files actually have.

- [x] an explanatory sentence each for `[0-9]` and `{2}` is needed.