### PR TITLE
Make folder-nature explicit in path arguments?

### DIFF
--- a/_episodes_rmd/03-loops-R.Rmd
+++ b/_episodes_rmd/03-loops-R.Rmd
@@ -284,8 +284,8 @@ Since no pattern is specified to filter the files, all files are returned.
 So to list all the csv files, we could run either of the following:
 
 ```{r}
-list.files(path = "data", pattern = "csv")
-list.files(path = "data", pattern = "inflammation")
+list.files(path = "data/", pattern = "csv")
+list.files(path = "data/", pattern = "inflammation")
 ```
 
 > ## Organizing Larger Projects
@@ -309,8 +309,8 @@ using the output of `list.files` we also need to include the "path" portion of t
 We can do that by using the argument `full.names = TRUE`.
 
 ```{r}
-list.files(path = "data", pattern = "csv", full.names = TRUE)
-list.files(path = "data", pattern = "inflammation", full.names = TRUE)
+list.files(path = "data/", pattern = "csv", full.names = TRUE)
+list.files(path = "data/", pattern = "inflammation", full.names = TRUE)
 ```
 
 
@@ -318,7 +318,7 @@ Let's test out running our `analyze` function by using it on the first three fil
 
 
 ```{r loop-analyze, fig=FALSE}
-filenames <- list.files(path = "data", pattern = "inflammation.*csv", full.names = TRUE)
+filenames <- list.files(path = "data/", pattern = "inflammation.*csv", full.names = TRUE)
 filenames <- filenames[1:3]
 for (f in filenames) {
   print(f)
@@ -349,7 +349,7 @@ Sure enough, the maxima of these data sets show exactly the same ramp as the fir
 > > analyze_all <- function(pattern) {
 > >   # Runs the function analyze for each file in the current working directory
 > >   # that contains the given pattern.
-> >   filenames <- list.files(path = "data", pattern = pattern, full.names = TRUE)
+> >   filenames <- list.files(path = "data/", pattern = pattern, full.names = TRUE)
 > >   for (f in filenames) {
 > >     analyze(f)
 > >   }

--- a/_episodes_rmd/04-cond.Rmd
+++ b/_episodes_rmd/04-cond.Rmd
@@ -52,7 +52,7 @@ And also built the function `analyze_all` to automate the processing of each dat
 analyze_all <- function(pattern) {
   # Runs the function analyze for each file in the current working directory
   # that contains the given pattern.
-  filenames <- list.files(path = "data", pattern = pattern, full.names = TRUE)
+  filenames <- list.files(path = "data/", pattern = pattern, full.names = TRUE)
   for (f in filenames) {
     analyze(f)
   }
@@ -279,7 +279,7 @@ In this case, "either" means "either or both", not "either one or the other but 
 > Complete the code below:
 >
 > ```{r, eval=FALSE}
-> filenames <- list.files(path = "data", pattern = "inflammation.*csv", full.names = TRUE)
+> filenames <- list.files(path = "data/", pattern = "inflammation.*csv", full.names = TRUE)
 > filename_max <- "" # filename where the maximum average inflammation patient is found
 > patient_max <- 0 # index (row number) for this patient in this file
 > average_inf_max <- 0 # value of the average inflammation score for this patient

--- a/_episodes_rmd/15-supp-loops-in-depth.Rmd
+++ b/_episodes_rmd/15-supp-loops-in-depth.Rmd
@@ -38,7 +38,7 @@ analyze <- function(filename) {
 ```
 
 ```{r files}
-filenames <- list.files(path = "data", pattern = "inflammation.*.csv", full.names = TRUE)
+filenames <- list.files(path = "data/", pattern = "inflammation.*.csv", full.names = TRUE)
 ```
 
 ### Vectorized Operations


### PR DESCRIPTION
As the learners saw in [shell-novice/02-filedir](https://github.com/swcarpentry/shell-novice/blob/gh-pages/_episodes/02-filedir.md), a trailing `/` differentiates as directory/folder from a file.

This is something we could reiterate here, but apparently at the cost of the console output duplicating the slash: `data//inflammation-01.csv`. Worth it?