### PR TITLE
Teach about roxygen2 earlier (closes #309)

### DIFF
--- a/_episodes_rmd/01-starting-with-data.Rmd
+++ b/_episodes_rmd/01-starting-with-data.Rmd
@@ -135,7 +135,7 @@ We can treat our variable like a regular number, and do arithmetic with it:
 
 > ## Commenting
 >
-> We can add comments to our code using the `#` character. It is useful to
+> We can add [comments]({{ page.root }}/reference/#comment) to our code using the `#` character. It is useful to
 > document our code in this way so that others (and us the next time we
 > read it) have an easier time following what the code is doing.
 {: .callout}

--- a/_episodes_rmd/02-func-R.Rmd
+++ b/_episodes_rmd/02-func-R.Rmd
@@ -284,7 +284,7 @@ We have one more task first, though: we should write some [documentation]({{ pag
 
 A common way to put documentation in software is to add "informal" comments like this:
 
-```{r}
+```{r center-commented, eval=FALSE}
 center <- function(data, desired) {
   # return a new vector containing the original data centered around the
   # desired value.
@@ -322,6 +322,33 @@ this conversion in [episode 8 "Making Packages in R"]({{ page.root }}/08-making-
 
 [LaTeX]: https://www.latex-project.org/
 [roxygen2]: https://cran.r-project.org/package=roxygen2/vignettes/rd.html
+
+For now, let's just lay a solid foundation of using [roxygen2's `#'` notation][roxygen2]
+for documenting functions. Please compare the following to the informal comments 
+we used above and in [episode 1 "Analyzing Patient Data"]({{ page.root }}/01-starting-with-data/):
+
+```{r center-roxygen}
+#' Centering Data (or another descriptive title for your function)
+#' 
+#' @param data The numeric vector to be centered
+#' @param desired The numeric value around which the data should be centered
+#'
+#' @return A new vector containing the original data centered around the desired value.
+#'
+#' @examples
+#'   center(c(1, 2, 3), 0)  # should return [1] -1  0  1
+center <- function(data, desired) {
+  new_data <- (data - mean(data)) + desired
+  return(new_data)
+}
+```
+
+Unsurprisingly, the first line should be a short, descriptive title. Additional 
+text paragraphs are possible after leaving one line blank with only a `#'`.
+The descriptive tags (preceded by an `@` symbol) hold the most important info. 
+`@param` documents a function's input parameters, while `@return` explains its 
+output. An accurate description of the in- and output data (types) helps to 
+successfully apply a function and integrate it into larger analysis pipelines.
 
 ```{r challenge-more-advanced-function-analyze, eval=FALSE, include=FALSE}
 analyze <- function(filename) {

--- a/_episodes_rmd/02-func-R.Rmd
+++ b/_episodes_rmd/02-func-R.Rmd
@@ -320,15 +320,6 @@ analyze <- function(filename) {
 }
 ```
 
-```{r challenge-more-advanced-function-rescale, include=FALSE}
-rescale <- function(v) {
-  # Rescales a vector, v, to lie in the range 0 to 1.
-  L <- min(v)
-  H <- max(v)
-  result <- (v - L) / (H - L)
-  return(result)
-}
-```
 
 > ## Functions to Create Graphs
 >
@@ -355,6 +346,15 @@ rescale <- function(v) {
 > > {: .r}
 > {: .solution}
 {: .challenge}
+
+```{r challenge-more-advanced-function-rescale, include=FALSE}
+rescale <- function(v) {
+  L <- min(v)
+  H <- max(v)
+  result <- (v - L) / (H - L)
+  return(result)
+}
+```
 
 > ## Rescaling
 >

--- a/_episodes_rmd/02-func-R.Rmd
+++ b/_episodes_rmd/02-func-R.Rmd
@@ -395,6 +395,12 @@ analyze <- function(filename) {
 > {: .solution}
 {: .challenge}
 
+If you are using RStudio, a nice shortcut is `CTRL`+`Shift`+`Alt`+`R`. Place the 
+cursor inside the function name or body, press that shortcut, 
+the roxygen2 function docu skeleton will be inserted. Note that we are not using 
+`@export` here, because it will only become relevant for [packaging]({{ page.root }}/reference/#packages).
+You can safely ignore it for now, or delete it.
+
 ```{r challenge-more-advanced-function-rescale, include=FALSE}
 rescale <- function(v) {
   L <- min(v)

--- a/_episodes_rmd/02-func-R.Rmd
+++ b/_episodes_rmd/02-func-R.Rmd
@@ -294,6 +294,7 @@ center <- function(data, desired) {
 }
 ```
 
+the code helps keeping the docu up to date when the code has to be changed. 
 > ## Technical details of R's help page format
 >
 > Help pages are rendered not directly from the roxygen2 comments, but from 
@@ -308,8 +309,6 @@ center <- function(data, desired) {
 
 ```{r challenge-more-advanced-function-analyze, eval=FALSE, include=FALSE}
 analyze <- function(filename) {
-  # Plots the average, min, and max inflammation over time.
-  # Input is character string of a csv file.
   dat <- read.csv(file = filename, header = FALSE)
   avg_day_inflammation <- apply(dat, 2, mean)
   plot(avg_day_inflammation)
@@ -331,9 +330,15 @@ analyze <- function(filename) {
 >
 > > ## Solution
 > > ~~~
+> > #' Analyse my Patient Inflammation Data 
+> > #'
+> > #' @param filename character string of a .csv file
+> > #'
+> > #' @return Plots of the average, min, and max inflammation over time.
+> > #'
+> > #' @examples 
+> > #'   analyze("data/inflammation-01.csv")
 > > analyze <- function(filename) {
-> >   # Plots the average, min, and max inflammation over time.
-> >   # Input is character string of a csv file.
 > >   dat <- read.csv(file = filename, header = FALSE)
 > >   avg_day_inflammation <- apply(dat, 2, mean)
 > >   plot(avg_day_inflammation)
@@ -360,14 +365,21 @@ rescale <- function(v) {
 >
 > Write a function `rescale` that takes a vector as input and returns a corresponding vector of values scaled to lie in the range 0 to 1.
 > (If $L$ and $H$ are the lowest and highest values in the original vector, then the replacement for a value $v$ should be $(v-L) / (H-L)$.)
-> Be sure to document your function with comments.
+> Be sure to document your function with roxygen2 comments.
 >
 > Test that your `rescale` function is working properly using `min`, `max`, and `plot`.
 >
 > > ## Solution
 > > ~~~
+> > #' Rescaling vectors to lie in the range 0 to 1
+> > #'
+> > #' @param v A numeric vector
+> > #'
+> > #' @return The rescaled numeric vector
+> > #'
+> > #' @examples
+> > #'   rescale(c(1, 2, 3), 0)  # should return [1] 0.0 0.5 1.0
 > > rescale <- function(v) {
-> >   # Rescales a vector, v, to lie in the range 0 to 1.
 > >   L <- min(v)
 > >   H <- max(v)
 > >   result <- (v - L) / (H - L)
@@ -408,10 +420,16 @@ dat <- read.csv(FALSE, "data/inflammation-01.csv")
 To understand what's going on, and make our own functions easier to use, let's re-define our `center` function like this:
 
 ```{r}
+#' Centering Data (or another descriptive title for your function)
+#' 
+#' @param data The numeric vector to be centered
+#' @param desired The numeric value around which the data should be centered (default = 0)
+#'
+#' @return A new vector containing the original data centered around the desired value.
+#'
+#' @examples
+#'   center(c(1, 2, 3), 0)  # should return [1] -1  0  1
 center <- function(data, desired = 0) {
-  # return a new vector containing the original data centered around the
-  # desired value (0 by default).
-  # Example: center(c(1, 2, 3), 0) => c(-1, 0, 1)
   new_data <- (data - mean(data)) + desired
   return(new_data)
 }

--- a/_episodes_rmd/02-func-R.Rmd
+++ b/_episodes_rmd/02-func-R.Rmd
@@ -280,6 +280,8 @@ all.equal(sd(dat[, 4]), sd(centered))
 It's still possible that our function is wrong, but it seems unlikely enough that we should probably get back to doing our analysis.
 We have one more task first, though: we should write some [documentation]({{ page.root }}/reference#documentation) for our function to remind ourselves later what it's for and how to use it.
 
+## Writing Documentation
+
 A common way to put documentation in software is to add function comments like this:
 
 ```{r}
@@ -292,15 +294,13 @@ center <- function(data, desired) {
 }
 ```
 
-> ## Writing Documentation
+> ## Technical details of R's help page format
 >
-> Formal documentation for R functions is written in separate `.Rd` using a
-> markup language similar to [LaTeX][]. You see the result of this documentation
-> when you look at the help file for a given function, e.g. `?read.csv`.
-> The [roxygen2][] package allows R coders to write documentation alongside
-> the function code and then process it into the appropriate `.Rd` files.
-> You will want to switch to this more formal method of writing documentation
-> when you start writing more complicated R projects.
+> Help pages are rendered not directly from the roxygen2 comments, but from 
+> `.Rd` files that use a markup language similar to [LaTeX]. 
+> [roxygen2] generates those `.Rd` files from the formal function documentation
+> comments. Therefore, R coders not have to write these LaTeX-like files separately,
+> but instead document their functions alongside the code.
 {: .callout}
 
 [LaTeX]: https://www.latex-project.org/

--- a/_episodes_rmd/02-func-R.Rmd
+++ b/_episodes_rmd/02-func-R.Rmd
@@ -280,7 +280,7 @@ all.equal(sd(dat[, 4]), sd(centered))
 It's still possible that our function is wrong, but it seems unlikely enough that we should probably get back to doing our analysis.
 We have one more task first, though: we should write some [documentation]({{ page.root }}/reference#documentation) for our function to remind ourselves later what it's for and how to use it.
 
-A common way to put documentation in software is to add [comments]({{ page.root }}/reference/#comment) like this:
+A common way to put documentation in software is to add function comments like this:
 
 ```{r}
 center <- function(data, desired) {
@@ -336,7 +336,7 @@ rescale <- function(v) {
 > and displays the three graphs produced in the [previous lesson][01] (average, min and max inflammation over time).
 > `analyze("data/inflammation-01.csv")` should produce the graphs already shown,
 > while `analyze("data/inflammation-02.csv")` should produce corresponding graphs for the second data set.
-> Be sure to document your function with comments.
+> Be sure to document your function with roxygen2 comments.
 >
 > > ## Solution
 > > ~~~

--- a/_episodes_rmd/02-func-R.Rmd
+++ b/_episodes_rmd/02-func-R.Rmd
@@ -282,7 +282,7 @@ We have one more task first, though: we should write some [documentation]({{ pag
 
 ## Writing Documentation
 
-A common way to put documentation in software is to add function comments like this:
+A common way to put documentation in software is to add "informal" comments like this:
 
 ```{r}
 center <- function(data, desired) {
@@ -294,7 +294,23 @@ center <- function(data, desired) {
 }
 ```
 
+This is a good practice to begin with. Keeping the documentation exactly next to 
 the code helps keeping the docu up to date when the code has to be changed. 
+However, such comments are not what we saw when using `?read.csv` to view a help 
+page.
+
+How can we create conveniently readable help pages for our own functions? By
+using the [roxygen2] package!
+
+```{r, eval=FALSE}
+install.packages("roxygen2")
+library("roxygen2")
+```
+
+It can convert "formal" documentation comments (lines starting with `#'`) into the 
+standard R format for help pages. You will learn  more about taking advantage of 
+this conversion in [episode 8 "Making Packages in R"]({{ page.root }}/08-making-packages-R/).
+
 > ## Technical details of R's help page format
 >
 > Help pages are rendered not directly from the roxygen2 comments, but from 

--- a/_episodes_rmd/08-making-packages-R.Rmd
+++ b/_episodes_rmd/08-making-packages-R.Rmd
@@ -90,7 +90,7 @@ fahrenheit_to_celsius <- function(temp_F) {
 }
 ```
 
-We will use the [`devtools`][devtools] and [`roxygen2`][roxygen2] packages, which make creating packages in R relatively simple. Both can be installed from CRAN like this:
+We will use the [`devtools`][devtools] package and [`roxygen2` from episode 2 "Creating Functions"]({{ page.root }}/02-func-R/), which make creating packages in R relatively simple. Both can be installed from CRAN like this:
 
 ```{r, eval=FALSE}
 install.packages(c("devtools", "roxygen2"))  # installations can be `c`ombined
@@ -127,7 +127,7 @@ fahrenheit_to_kelvin <- function(temp_F) {
 }
 ```
 
-The `roxygen2` package reads lines that begin with `#'` as comments to create the documentation for your package.
+The `roxygen2` package reads lines that begin with `#'` as the function documentation for your package.
 Descriptive tags are preceded with the `@` symbol. For example, `@param` has information about the input parameters for the function.
 Now, we will use `roxygen2` to convert our documentation to the standard R format.
 


### PR DESCRIPTION
This provides a suggestion to implement #309.

- [ ] trim town `08` to only repeat a bit of the earlier roxygen2 info