### PR TITLE
Rephrase to avoid misinterpretation as pipeline

### DIFF
--- a/_episodes_rmd/02-func-R.Rmd
+++ b/_episodes_rmd/02-func-R.Rmd
@@ -105,12 +105,12 @@ This is our first taste of how larger programs are built: we define basic
 operations, then combine them in ever-larger chunks to get the effect we want.
 Real-life functions will usually be larger than the ones shown here--typically half a dozen to a few dozen lines--but they shouldn't ever be much longer than that, or the next person who reads it won't be able to understand what's going on.
 
-> ## Chaining Functions
+> ## Nesting Functions
 >
 > This example showed the output of `fahrenheit_to_kelvin` assigned to `temp_K`, which
 > is then passed to `kelvin_to_celsius` to get the final result. It is also possible
-> to perform this calculation in one line of code, by "chaining" functions
-> together, like so:
+> to perform this calculation in one line of code, by "nesting" one function
+> inside another, like so:
 >
 > ```{r chained-example}
 > # freezing point of water in Celsius


### PR DESCRIPTION
Hello! I haven't found a discussion about chaining vs. nesting in this issues, but in https://github.com/swcarpentry/python-novice-inflammation/pull/244#issuecomment-201909951 "nesting" is used for example what we have here at https://github.com/swcarpentry/r-novice-inflammation/blame/d1773f4ae7e0dfae36c456e39a6647fd0baba986/_episodes/02-func-R.md#L149-L159

Because our learners are likely to encounter `magrittr`-"pipelining", how about we avoid the in-between term "chain" here?