### PR TITLE
Collect lesson link (see #371)

### DIFF
--- a/_episodes_rmd/06-best-practices-R.Rmd
+++ b/_episodes_rmd/06-best-practices-R.Rmd
@@ -141,7 +141,7 @@ rm(list = ls()) # If you want to delete all the objects in the workspace and sta
 
 8. Collaborate. Grab a buddy and practice "code review". Review is used for preparing experiments and manuscripts; why not use it for code as well? Our code is also a major scientific achievement and the product of lots of hard work!
 
-9. Develop your code using version control and frequent updates! You can find lessons about version control on [software-carpentry.org/lessons][lessons].
+9. Develop your code using version control and frequent updates! You can find lessons about version control on [software-carpentry.org/lessons][swc-lessons].
 
 > ## Best Practice
 >


### PR DESCRIPTION
This depends on carpentries/styles#303. Best merge afterwards.

Or: it should be possible to add that link to `links.md` without causing a conflict later when a new styles release is merged. Git checks the line differences first, before selecting the commits to include in a PR, right? So, at worst an empty commit is added if its change has already been applied earlier.