### PR TITLE
this addresses fix #379. Content has been added to the matrix section…

### DIFF
--- a/_episodes_rmd/13-supp-data-structures.Rmd
+++ b/_episodes_rmd/13-supp-data-structures.Rmd
@@ -267,6 +267,16 @@ m
 dim(m)
 ```
 
+You can check that matrices are vectors with a class attribute of `matrix` by using `class()` and `typeof()`.
+
+```{r}
+m <- matrix(c(1:3))
+class(m)
+typeof(m)
+```
+
+While `class()` shows that m is a matrix, `typeof()` shows that fundamentally the matrix is an integer vector.
+
 Matrices in R are filled column-wise.
 
 ```{r}


### PR DESCRIPTION
… to show the difference between the `class()` and `typeof()` functions and to show the matrices are vectors. The data-frame section was not modified as it uses `is.list()` in combination with `class()` to show this as well.