### PR TITLE
Align margin order in fig/r-operations-across-margins.svg with text

### DIFF
--- a/fig/r-operations-across-margins.svg
+++ b/fig/r-operations-across-margins.svg
@@ -9,15 +9,15 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.2"
-   width="513.76117"
-   height="269.27908"
-   viewBox="0 0 14499.482 7599.6541"
+   width="331.29922"
+   height="268.1983"
+   viewBox="0 0 9350.0004 7569.1521"
    preserveAspectRatio="xMidYMid"
    clip-path="url(#presentation_clip_path)"
    xml:space="preserve"
    id="svg12375"
-   inkscape:version="0.48.2 r9819"
-   sodipodi:docname="python-operations-across-axes.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="r-operations-across-margins.svg"
    style="fill-rule:evenodd;stroke-width:28.22200012;stroke-linejoin:round"><metadata
    id="metadata12613"><rdf:RDF><cc:Work
        rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
@@ -30,21 +30,21 @@
    guidetolerance="10"
    inkscape:pageopacity="0"
    inkscape:pageshadow="2"
-   inkscape:window-width="640"
-   inkscape:window-height="480"
+   inkscape:window-width="1858"
+   inkscape:window-height="1177"
    id="namedview12611"
    showgrid="false"
    fit-margin-top="0"
    fit-margin-left="0"
    fit-margin-right="0"
    fit-margin-bottom="0"
-   inkscape:zoom="0.23838384"
-   inkscape:cx="337.32283"
-   inkscape:cy="-184.08705"
-   inkscape:window-x="0"
-   inkscape:window-y="0"
-   inkscape:window-maximized="0"
-   inkscape:current-layer="svg12375" />
+   inkscape:zoom="1.9070707"
+   inkscape:cx="126.76606"
+   inkscape:cy="226.54039"
+   inkscape:window-x="54"
+   inkscape:window-y="-8"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g12424" />
  <defs
    class="ClipPathGroup"
    id="defs12377">
@@ -72,39 +72,39 @@
    id="defs12386">
   <g
    id="bullet-char-template(57356)"
-   transform="scale(4.8828125e-4,-4.8828125e-4)">
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)">
    <path
-   d="M 580,1141 1163,571 580,0 -4,571 580,1141 z"
+   d="M 580,1141 1163,571 580,0 -4,571 Z"
    id="path12389"
    inkscape:connector-curvature="0" />
   </g>
   <g
    id="bullet-char-template(57354)"
-   transform="scale(4.8828125e-4,-4.8828125e-4)">
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)">
    <path
-   d="m 8,1128 1129,0 L 1137,0 8,0 8,1128 z"
+   d="M 8,1128 H 1137 V 0 H 8 Z"
    id="path12392"
    inkscape:connector-curvature="0" />
   </g>
   <g
    id="bullet-char-template(10146)"
-   transform="scale(4.8828125e-4,-4.8828125e-4)">
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)">
    <path
-   d="M 174,0 602,739 174,1481 1456,739 174,0 z m 1184,739 -1049,607 350,-607 699,0 z"
+   d="M 174,0 602,739 174,1481 1456,739 Z M 1358,739 309,1346 659,739 Z"
    id="path12395"
    inkscape:connector-curvature="0" />
   </g>
   <g
    id="bullet-char-template(10132)"
-   transform="scale(4.8828125e-4,-4.8828125e-4)">
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)">
    <path
-   d="M 2015,739 1276,0 717,0 l 543,543 -1086,0 0,393 1086,0 -543,545 557,0 741,-742 z"
+   d="M 2015,739 1276,0 H 717 l 543,543 H 174 v 393 h 1086 l -543,545 h 557 z"
    id="path12398"
    inkscape:connector-curvature="0" />
   </g>
   <g
    id="bullet-char-template(10007)"
-   transform="scale(4.8828125e-4,-4.8828125e-4)">
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)">
    <path
    d="m 0,-2 c -7,16 -16,29 -25,39 l 381,530 c -94,256 -141,385 -141,387 0,25 13,38 40,38 9,0 21,-2 34,-5 21,4 42,12 65,25 l 27,-13 111,-251 280,301 64,-25 24,25 c 21,-10 41,-24 62,-43 C 886,937 835,863 770,784 769,783 710,716 594,584 L 774,223 c 0,-27 -21,-55 -63,-84 l 16,-20 C 717,90 699,76 672,76 641,76 570,178 457,381 L 164,-76 c -22,-34 -53,-51 -92,-51 -42,0 -63,17 -64,51 -7,9 -10,24 -10,44 0,9 1,19 2,30 z"
    id="path12401"
@@ -112,23 +112,23 @@
   </g>
   <g
    id="bullet-char-template(10004)"
-   transform="scale(4.8828125e-4,-4.8828125e-4)">
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)">
    <path
-   d="M 285,-33 C 182,-33 111,30 74,156 52,228 41,333 41,471 c 0,78 14,145 41,201 34,71 87,106 158,106 53,0 88,-31 106,-94 l 23,-176 c 8,-64 28,-97 59,-98 l 735,706 c 11,11 33,17 66,17 42,0 63,-15 63,-46 l 0,-122 c 0,-36 -10,-64 -30,-84 L 442,47 C 390,-6 338,-33 285,-33 z"
+   d="M 285,-33 C 182,-33 111,30 74,156 52,228 41,333 41,471 c 0,78 14,145 41,201 34,71 87,106 158,106 53,0 88,-31 106,-94 l 23,-176 c 8,-64 28,-97 59,-98 l 735,706 c 11,11 33,17 66,17 42,0 63,-15 63,-46 V 965 c 0,-36 -10,-64 -30,-84 L 442,47 C 390,-6 338,-33 285,-33 Z"
    id="path12404"
    inkscape:connector-curvature="0" />
   </g>
   <g
    id="bullet-char-template(9679)"
-   transform="scale(4.8828125e-4,-4.8828125e-4)">
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)">
    <path
-   d="M 813,0 C 632,0 489,54 383,161 276,268 223,411 223,592 c 0,181 53,324 160,431 106,107 249,161 430,161 179,0 323,-54 432,-161 108,-107 162,-251 162,-431 0,-180 -54,-324 -162,-431 C 1136,54 992,0 813,0 z"
+   d="M 813,0 C 632,0 489,54 383,161 276,268 223,411 223,592 c 0,181 53,324 160,431 106,107 249,161 430,161 179,0 323,-54 432,-161 108,-107 162,-251 162,-431 0,-180 -54,-324 -162,-431 C 1136,54 992,0 813,0 Z"
    id="path12407"
    inkscape:connector-curvature="0" />
   </g>
   <g
    id="bullet-char-template(8226)"
-   transform="scale(4.8828125e-4,-4.8828125e-4)">
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)">
    <path
    d="m 346,457 c -73,0 -137,26 -191,78 -54,51 -81,114 -81,188 0,73 27,136 81,188 54,52 118,78 191,78 73,0 134,-26 185,-79 51,-51 77,-114 77,-187 0,-75 -25,-137 -76,-188 -50,-52 -112,-78 -186,-78 z"
    id="path12410"
@@ -136,9 +136,9 @@
   </g>
   <g
    id="bullet-char-template(8211)"
-   transform="scale(4.8828125e-4,-4.8828125e-4)">
+   transform="matrix(4.8828125e-4,0,0,-4.8828125e-4,0,0)">
    <path
-   d="m -4,459 1139,0 0,147 -1139,0 0,-147 z"
+   d="M -4,459 H 1135 V 606 H -4 Z"
    id="path12413"
    inkscape:connector-curvature="0" />
   </g>
@@ -179,7 +179,7 @@
       <g
    id="id3">
        <path
-   d="m 8600,7200 -2000,0 0,-6000 4000,0 0,6000 -2000,0 z"
+   d="M 8600,7200 H 6600 V 1200 h 4000 v 6000 z"
    id="path12432"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -191,7 +191,7 @@
       <g
    id="id4">
        <path
-   d="m 7600,1200 0,6000"
+   d="M 7600,1200 V 7200"
    id="path12437"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -203,7 +203,7 @@
       <g
    id="id5">
        <path
-   d="m 9600,1200 0,6000"
+   d="M 9600,1200 V 7200"
    id="path12442"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -215,7 +215,7 @@
       <g
    id="id6">
        <path
-   d="m 8600,1200 0,6000"
+   d="M 8600,1200 V 7200"
    id="path12447"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -227,7 +227,7 @@
       <g
    id="id7">
        <path
-   d="m 6600,2200 4000,0"
+   d="m 6600,2200 h 4000"
    id="path12452"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -239,7 +239,7 @@
       <g
    id="id8">
        <path
-   d="m 6600,3200 4000,0"
+   d="m 6600,3200 h 4000"
    id="path12457"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -251,7 +251,7 @@
       <g
    id="id9">
        <path
-   d="m 6600,4200 4000,0"
+   d="m 6600,4200 h 4000"
    id="path12462"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -263,7 +263,7 @@
       <g
    id="id10">
        <path
-   d="m 6600,5200 4000,0"
+   d="m 6600,5200 h 4000"
    id="path12467"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -275,7 +275,7 @@
       <g
    id="id11">
        <path
-   d="m 6600,6200 4000,0"
+   d="m 6600,6200 h 4000"
    id="path12472"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -287,12 +287,12 @@
       <g
    id="id12">
        <path
-   d="m 7100,1700 3970,0"
+   d="M 1737.782,1700 H 5707.7892"
    id="path12477"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000" />
        <path
-   d="m 11500,1700 -450,-150 0,300 450,-150 z"
+   d="m 6137.7924,1700 -450.0032,-150 v 300 z"
    id="path12479"
    inkscape:connector-curvature="0"
    style="fill:#000000;stroke:none" />
@@ -304,12 +304,12 @@
       <g
    id="id13">
        <path
-   d="m 7100,2700 3970,0"
+   d="M 1737.782,2700 H 5707.7892"
    id="path12484"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000" />
        <path
-   d="m 11500,2700 -450,-150 0,300 450,-150 z"
+   d="m 6137.7924,2700 -450.0032,-150 v 300 z"
    id="path12486"
    inkscape:connector-curvature="0"
    style="fill:#000000;stroke:none" />
@@ -321,12 +321,12 @@
       <g
    id="id14">
        <path
-   d="m 7100,3700 3970,0"
+   d="M 1737.782,3700 H 5707.7892"
    id="path12491"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000" />
        <path
-   d="m 11500,3700 -450,-150 0,300 450,-150 z"
+   d="m 6137.7924,3700 -450.0032,-150 v 300 z"
    id="path12493"
    inkscape:connector-curvature="0"
    style="fill:#000000;stroke:none" />
@@ -338,12 +338,12 @@
       <g
    id="id15">
        <path
-   d="m 7100,4700 3970,0"
+   d="M 1737.782,4700 H 5707.7892"
    id="path12498"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000" />
        <path
-   d="m 11500,4700 -450,-150 0,300 450,-150 z"
+   d="m 6137.7924,4700 -450.0032,-150 v 300 z"
    id="path12500"
    inkscape:connector-curvature="0"
    style="fill:#000000;stroke:none" />
@@ -355,12 +355,12 @@
       <g
    id="id16">
        <path
-   d="m 7100,5700 3970,0"
+   d="M 1737.782,5700 H 5707.7892"
    id="path12505"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000" />
        <path
-   d="m 11500,5700 -450,-150 0,300 450,-150 z"
+   d="m 6137.7924,5700 -450.0032,-150 v 300 z"
    id="path12507"
    inkscape:connector-curvature="0"
    style="fill:#000000;stroke:none" />
@@ -372,12 +372,12 @@
       <g
    id="id17">
        <path
-   d="m 7100,6700 3970,0"
+   d="M 1737.782,6700 H 5707.7892"
    id="path12512"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000" />
        <path
-   d="m 11500,6700 -450,-150 0,300 450,-150 z"
+   d="m 6137.7924,6700 -450.0032,-150 v 300 z"
    id="path12514"
    inkscape:connector-curvature="0"
    style="fill:#000000;stroke:none" />
@@ -389,7 +389,7 @@
       <g
    id="id18">
        <path
-   d="m 3300,7200 -2000,0 0,-6000 4000,0 0,6000 -2000,0 z"
+   d="M 3300,7200 H 1300 V 1200 h 4000 v 6000 z"
    id="path12519"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -401,7 +401,7 @@
       <g
    id="id19">
        <path
-   d="m 2300,1200 0,6000"
+   d="M 2300,1200 V 7200"
    id="path12524"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -413,7 +413,7 @@
       <g
    id="id20">
        <path
-   d="m 4300,1200 0,6000"
+   d="M 4300,1200 V 7200"
    id="path12529"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -425,7 +425,7 @@
       <g
    id="id21">
        <path
-   d="m 3300,1200 0,6000"
+   d="M 3300,1200 V 7200"
    id="path12534"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -437,7 +437,7 @@
       <g
    id="id22">
        <path
-   d="m 1300,2200 4000,0"
+   d="M 1300,2200 H 5300"
    id="path12539"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -449,7 +449,7 @@
       <g
    id="id23">
        <path
-   d="m 1300,3200 4000,0"
+   d="M 1300,3200 H 5300"
    id="path12544"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -461,7 +461,7 @@
       <g
    id="id24">
        <path
-   d="m 1300,4200 4000,0"
+   d="M 1300,4200 H 5300"
    id="path12549"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -473,7 +473,7 @@
       <g
    id="id25">
        <path
-   d="m 1300,5200 4000,0"
+   d="M 1300,5200 H 5300"
    id="path12554"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -485,7 +485,7 @@
       <g
    id="id26">
        <path
-   d="m 1300,6200 4000,0"
+   d="M 1300,6200 H 5300"
    id="path12559"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000;stroke-width:50" />
@@ -497,12 +497,12 @@
       <g
    id="id27">
        <path
-   d="m 1800,1700 0,5870"
+   d="M 7105.7736,1700 V 7570"
    id="path12564"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000" />
        <path
-   d="m 1800,8000 150,-450 -300,0 150,450 z"
+   d="m 7105.7736,8000 150,-450 h -300 z"
    id="path12566"
    inkscape:connector-curvature="0"
    style="fill:#000000;stroke:none" />
@@ -514,12 +514,12 @@
       <g
    id="id28">
        <path
-   d="m 2800,1700 0,5870"
+   d="M 8105.7736,1700 V 7570"
    id="path12571"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000" />
        <path
-   d="m 2800,8000 150,-450 -300,0 150,450 z"
+   d="m 8105.7736,8000 150,-450 h -300 z"
    id="path12573"
    inkscape:connector-curvature="0"
    style="fill:#000000;stroke:none" />
@@ -531,12 +531,12 @@
       <g
    id="id29">
        <path
-   d="m 3800,1700 0,5870"
+   d="M 9105.7736,1700 V 7570"
    id="path12578"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000" />
        <path
-   d="m 3800,8000 150,-450 -300,0 150,450 z"
+   d="m 9105.7736,8000 150,-450 h -300 z"
    id="path12580"
    inkscape:connector-curvature="0"
    style="fill:#000000;stroke:none" />
@@ -548,12 +548,12 @@
       <g
    id="id30">
        <path
-   d="m 4800,1700 0,5870"
+   d="M 10105.773,1700 V 7570"
    id="path12585"
    inkscape:connector-curvature="0"
    style="fill:none;stroke:#000000" />
        <path
-   d="m 4800,8000 150,-450 -300,0 150,450 z"
+   d="m 10105.773,8000 149.999,-450 h -299.9984 z"
    id="path12587"
    inkscape:connector-curvature="0"
    style="fill:#000000;stroke:none" />
@@ -566,18 +566,21 @@
    id="id31">
        <text
    class="TextShape"
-   id="text12592"><tspan
+   id="text12592"
+   style="line-height:0%"
+   x="338.66669"><tspan
      class="TextParagraph"
      font-size="388px"
      font-weight="400"
      id="tspan12594"
-     style="font-size:388px;font-weight:400;font-family:'Arial, sans-serif'"><tspan
+     style="font-weight:400;font-size:388px"><tspan
        class="TextPosition"
-       x="1472"
+       x="1810.6667"
        y="8693"
        id="tspan12596"><tspan
          id="tspan12598"
-         style="fill:#000000;stroke:none">across columns (2)</tspan></tspan></tspan></text>
+         style="fill:#000000;stroke:none">across rows (1)</tspan></tspan></tspan></text>
+
 
       </g>
      </g>
@@ -588,18 +591,22 @@
    id="id32">
        <text
    class="TextShape"
-   id="text12603"><tspan
+   id="text12603"
+   style="line-height:0%"
+   x="-5305.772"
+   y="4289.7739"><tspan
      class="TextParagraph"
      font-size="388px"
      font-weight="400"
      id="tspan12605"
-     style="font-size:388px;font-weight:400;font-family:'Arial, sans-serif'"><tspan
+     style="font-weight:400;font-size:388px"><tspan
        class="TextPosition"
-       x="12072"
-       y="4376"
+       x="6766.2324"
+       y="8665.7695"
        id="tspan12607"><tspan
          id="tspan12609"
-         style="fill:#000000;stroke:none">across rows (1)</tspan></tspan></tspan></text>
+         style="fill:#000000;stroke:none">across columns (2)</tspan></tspan></tspan></text>
+
 
       </g>
      </g>


### PR DESCRIPTION
Hi! I'm always confused about the `apply(.., MARGIN = ...)` and I want to try whether swapping the order in the figure helps. Please compare visually: [current](https://github.com/swcarpentry/r-novice-inflammation/blob/master/fig/r-operations-across-margins.svg) vs. [swapped](https://github.com/swcarpentry/r-novice-inflammation/blob/537424e5bb317e894f7689389864a4125c12e10c/fig/r-operations-across-margins.svg).