### PR TITLE
Harmonise mention of Shell lesson

### DIFF
--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -89,7 +89,7 @@ line and this should resolve the issue.
 
 *   The discussion of command-line scripts
     assumes that students understand standard I/O and building filters,
-    which are covered in the lesson on the shell.
+    which are covered in the [Shell lesson](https://swcarpentry.github.io/shell-novice/).
 
 *   We are using a dataset with records on inflammation from patients following an
     arthritis treatment. With it we explain `R` data structure, basic data
@@ -98,7 +98,7 @@ line and this should resolve the issue.
 ## [Analyzing Patient Data]({{ page.root }}/01-starting-with-data/)
 
 *   Check learners are reading files from the correct location (set working
-    directory); remind them of the shell lesson.
+    directory); remind them of the [Shell lesson](https://swcarpentry.github.io/shell-novice/).
 
 *   Provide shortcut for the assignment operator (`<-`) (RStudio: <kbd>Alt</kbd>+<kbd>-</kbd> on
     Windows/Linux; <kbd>Option</kbd>+<kbd>-</kbd> on Mac).


### PR DESCRIPTION
This is mostly a test to see whether my observation in https://github.com/swcarpentry/r-novice-inflammation/pull/396#issuecomment-428658927 is correct.

- [x] after Travis finished, check https://swcarpentry.github.io/r-novice-inflammation/guide/. It should still say `lesson on the shell` and `shell lesson` without hyperlink.

If it has hyperlinked `Shell lesson` twice, Travis seems to deploy PRs straight away, before merging. Which was probably not intended by https://github.com/swcarpentry/r-novice-inflammation/issues/236#issuecomment-420317665 was it? cc @fmichonneau 