### PR TITLE
Introduce `colnames` instead of `names` for data frames

### DIFF
--- a/_episodes_rmd/10-supp-addressing-data.Rmd
+++ b/_episodes_rmd/10-supp-addressing-data.Rmd
@@ -112,12 +112,12 @@ Returns the first 5 columns for patients in rows 1,5,7 & 9
 Columns in an R data frame are named.
 
 ```{r column_names}
-names(dat)
+colnames(dat)
 ```
 
 > ## Default Names
 >
-> If names are not specified e.g. using `headers = FALSE` in a `read.csv()` function, R assigns default names `V1, V2, ..., Vn`
+> If column names are not specified e.g. using `headers = FALSE` in a `read.csv()` function, R assigns default names `V1, V2, ..., Vn`
 {: .callout}
 
 We usually use the `$` operator to address a column by name


### PR DESCRIPTION
The usage of `colnames` for data frames is more self-explanatory, and consistent with introducing `rownames` in a further lesson. This closes #315.