### PR TITLE
Adding options(stringsAsFactors=FALSE)

### DIFF
--- a/_episodes_rmd/11-supp-read-write-csv.Rmd
+++ b/_episodes_rmd/11-supp-read-write-csv.Rmd
@@ -115,6 +115,19 @@ carSpeeds$Color
 ```
 
 That's better! And we can see how the data now is read as character instead of factor.
+ 
+ 
+ 
+Alternatively, if we want to prevent characters from converting to factors, we can change R's default behavior by using `options(stringsAsFactors=FALSE)`. This will change the default value of the 'stringsAsFactors' argument to FALSE in all functions that utilize this parameter without us having to do so manually. 
+
+```{r optionsStringsAsFactorFALSE}
+options(stringsAsFactors=FALSE)
+carSpeeds <- read.csv(file = 'data/car-speeds.csv')
+str(carSpeeds)
+```
+
+See ?options for more details about the function and a list of other default settings that can be changed.
+
 
 
 ### The `as.is` Argument


### PR DESCRIPTION
Revisiting #393, I noticed that @duytpm16's commit was not in any PR, yet. It:

> add['s] a little section on options(stringsAsFactors = FALSE) under  `The `stringsAsFactors` Argument`[and] add['s] a short line of code as well to show how it works. […]

I am a bit skeptical of `options()` ([similarly to `setwd()` or `rm(list = ls())`](https://twitter.com/JennyBryan/status/997004754759778305)) to be honest, but it at least works only during the current session.

The alternative would be to solve @duytpm16's usecase

> don't … manually set `stringAsFactors` to `FALSE` when … reading in multiple files

by teaching to wrap the `read…` function into a custom one, similarly to the ["Functions to Create Graphs" challenge](https://swcarpentry.github.io/r-novice-inflammation/02-func-R/#functions-to-create-graphs). See esp. [my last review comment](https://github.com/swcarpentry/r-novice-inflammation/pull/419#discussion_r277174511), but I wanted to give this suggestion a fair chance & discussion.