### PR TITLE
Upgrade 06-best-practices with more references or even practices?

### DIFF
--- a/_episodes_rmd/06-best-practices-R.Rmd
+++ b/_episodes_rmd/06-best-practices-R.Rmd
@@ -115,7 +115,7 @@ source("my_genius_fxns.R")
 
 3. Don't repeat yourself--automate! If you are repeating the same code over and over, use a loop or a function to repeat that code for you. Needless repetition doesn't just waste time--it also increases the likelihood you'll make a costly mistake!
 
-4. Keep all of your source files for a project in the same directory, then use relative paths as necessary to access them. For example, use
+4. Keep all of your source files for a [project in the same directory][rstudio-project], then use relative paths as necessary to access them. For example, use
 
 ```{r relpath, eval=FALSE}
 dat <- read.csv(file = "files/dataset-2013-01.csv", header = TRUE)
@@ -143,11 +143,11 @@ rm(list = ls()) # If you want to delete all the objects in the workspace and sta
 ```
 
 {:start="6"}
-6. Don't save a session history (the default option in R, when it asks if you want an `RData` file). Instead, start in a clean environment so that older objects don't remain in your environment any longer than they need to. If that happens, it can lead to unexpected results.
+6. [Don't save a session history][dc-rstudio] (the default option in R, when it asks if you want an `RData` file). Instead, start in a clean environment so that older objects don't remain in your environment any longer than they need to. If that happens, it can lead to unexpected results.
 
-7. Wherever possible, keep track of `sessionInfo()` somewhere in your project folder. Session information is invaluable because it captures all of the packages used in the current project. If a newer version of a package changes the way a function behaves, you can always go back and reinstall the version that worked (Note: At least on CRAN, all older versions of packages are permanently archived).
+7. Wherever possible, [keep track of `sessionInfo()` somewhere][sessionInfo] in your project folder. Session information is invaluable because it captures all of the packages used in the current project. If a newer version of a package changes the way a function behaves, you can always go back and reinstall the version that worked (Note: At least on CRAN, all older versions of packages are permanently archived).
 
-8. Collaborate. Grab a buddy and practice "code review". Review is used for preparing experiments and manuscripts; why not use it for code as well? Our code is also a major scientific achievement and the product of lots of hard work!
+8. Collaborate. Grab a buddy and practice "code review". Review is used for preparing experiments and manuscripts; why not use it for code as well? Our code is also a major scientific achievement and the product of lots of hard work! Reviews are built into [GitHub's Pull request feature][gh-pr]
 
 > ## Best Practice
 >

--- a/_episodes_rmd/06-best-practices-R.Rmd
+++ b/_episodes_rmd/06-best-practices-R.Rmd
@@ -42,6 +42,11 @@ Starting your code with an annotated description of what the code does when it i
 # paper. Code developed by Sarah Supp, Tracy Teal, and Jon Borelli
 ```
 
+Also consider version-controlling your code as for example taught by
+[Software Carpentry's `git-novice` lessons][swc-lesson-git].
+Frequent commits with explanatory, synoptic commit messages are an elegant way
+to comment code. [RStudio enables this with a Git integration][rstudio-git].
+
 ### Be explicit about the requirements and dependencies of your code
 
 Loading all of the packages that will be necessary to run your code (using `library`) is a nice way of indicating which packages are necessary to run your code. It can be frustrating to make it two-thirds of the way through a long-running script only to find out that a dependency hasn't been installed.
@@ -143,8 +148,6 @@ rm(list = ls()) # If you want to delete all the objects in the workspace and sta
 7. Wherever possible, keep track of `sessionInfo()` somewhere in your project folder. Session information is invaluable because it captures all of the packages used in the current project. If a newer version of a package changes the way a function behaves, you can always go back and reinstall the version that worked (Note: At least on CRAN, all older versions of packages are permanently archived).
 
 8. Collaborate. Grab a buddy and practice "code review". Review is used for preparing experiments and manuscripts; why not use it for code as well? Our code is also a major scientific achievement and the product of lots of hard work!
-
-9. Develop your code using version control and frequent updates! You can find lessons about version control on [software-carpentry.org/lessons][swc-lessons].
 
 > ## Best Practice
 >

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -39,7 +39,7 @@
 [pyyaml]: https://pypi.python.org/pypi/PyYAML
 [r-markdown]: https://rmarkdown.rstudio.com/
 [rstudio]: https://www.rstudio.com/
-[rstudio-git]: https://support.rstudio.com/hc/en-us/articles/200532077
+[rstudio-git]: https://web.archive.org/web/20190103191213/https://support.rstudio.com/hc/en-us/articles/200532077
 [rstudio-project]: https://resources.rstudio.com/wistia-rstudio-essentials-2/rstudioessentialsmanagingpart1-2
 [ruby-install-guide]: https://www.ruby-lang.org/en/downloads/
 [ruby-installer]: https://rubyinstaller.org/

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -10,8 +10,10 @@
 [cran-knitr]: https://cran.r-project.org/package=knitr
 [cran-stringr]: https://cran.r-project.org/package=stringr
 [dc-lessons]: http://www.datacarpentry.org/lessons/
+[dc-rstudio]: https://datacarpentry.org/R-ecology-lesson/00-before-we-start.html#getting_set_up
 [email]: mailto:team@carpentries.org
 [github-importer]: https://import.github.com/
+[gh-pr]: https://lab.github.com/githubtraining/reviewing-pull-requests
 [importer]: https://github.com/new/import
 [jekyll-collection]: https://jekyllrb.com/docs/collections/
 [jekyll-install]: https://jekyllrb.com/docs/installation/
@@ -38,9 +40,11 @@
 [r-markdown]: https://rmarkdown.rstudio.com/
 [rstudio]: https://www.rstudio.com/
 [rstudio-git]: https://support.rstudio.com/hc/en-us/articles/200532077
+[rstudio-project]: https://resources.rstudio.com/wistia-rstudio-essentials-2/rstudioessentialsmanagingpart1-2
 [ruby-install-guide]: https://www.ruby-lang.org/en/downloads/
 [ruby-installer]: https://rubyinstaller.org/
 [rubygems]: https://rubygems.org/pages/download/
+[sessionInfo]: https://stackoverflow.com/a/21967272/4341322
 [styles]: https://github.com/carpentries/styles/
 [swc-lesson-git]: https://swcarpentry.github.io/git-novice/
 [swc-releases]: https://github.com/swcarpentry/swc-releases

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -37,11 +37,12 @@
 [pyyaml]: https://pypi.python.org/pypi/PyYAML
 [r-markdown]: https://rmarkdown.rstudio.com/
 [rstudio]: https://www.rstudio.com/
+[rstudio-git]: https://support.rstudio.com/hc/en-us/articles/200532077
 [ruby-install-guide]: https://www.ruby-lang.org/en/downloads/
 [ruby-installer]: https://rubyinstaller.org/
 [rubygems]: https://rubygems.org/pages/download/
 [styles]: https://github.com/carpentries/styles/
-[swc-lessons]: https://software-carpentry.org/lessons/ 
+[swc-lesson-git]: https://swcarpentry.github.io/git-novice/
 [swc-releases]: https://github.com/swcarpentry/swc-releases
 [tex-eq]: https://latex.codecogs.com/gif.latex?%5Calpha%20%3D%20%5Cdfrac%7B1%7D%7B%281%20-%20%5Cbeta%29%5E2%7D
 [training]: https://carpentries.github.io/instructor-training/


### PR DESCRIPTION
Besides, this PR drafts & discusses a few related upgrades, namely suggestsions to include more references to enable learners to read more about the reasoning behind each item we suggest. I think we should avoid including _more_ suggestions, unless they are short and backed by references.

My goal here is to:

- [x] suggest references for the existing best practices

to exemplify the above.