### PR TITLE
Update line-count.R

### DIFF
--- a/_episodes_rmd/line-count.R
+++ b/_episodes_rmd/line-count.R
@@ -8,12 +8,12 @@ main <- function() {
       cat(filename)
       cat(" ")
       cat(num_lines, sep = "\n")
-      if (length(args) > 1) {
-        total_lines = total_lines + num_lines
-      }
+      total_lines <- total_lines + num_lines
     }
-    cat("Total ")
-    cat(total_lines, sep = "\n")
+    if (length(args) > 1) {
+      cat("Total ")
+      cat(total_lines, sep = "\n")
+    }
   } else {
     input <- readLines(file("stdin"))
     num_lines <- length(input)


### PR DESCRIPTION
Original version incorrectly counts total line numbers if only one filename provided on command line. Removing the `if (length(args) > 1)` check fixes that. 
