### PR TITLE
Update deprecated devtools function (fix #441)

### DIFF
--- a/_episodes_rmd/08-making-packages-R.Rmd
+++ b/_episodes_rmd/08-making-packages-R.Rmd
@@ -109,7 +109,7 @@ Keep the name simple and unique.
 
 ```{r, eval=FALSE}
 setwd(parentDirectory)
-create("tempConvert")
+create_package("tempConvert")
 ```
 
 Add our functions to the R directory.


### PR DESCRIPTION
Whoa, did they remove that without deprecation warning? [It's back in](https://github.com/r-lib/devtools/commit/bf02cdaf86f0f8503745ef029a973233f9be7cff) for now, but still: We can safely follow this renaming, IMHO.