### PR TITLE
Added location to save scripts for cmdline programs

### DIFF
--- a/_episodes_rmd/05-cmdline.Rmd
+++ b/_episodes_rmd/05-cmdline.Rmd
@@ -63,7 +63,8 @@ We'll tackle these questions in turn below.
 
 ### Command-Line Arguments
 
-Using the text editor of your choice, save the following line of code in a text file called `session-info.R`:
+When using R scripts with the command-line, save/store scripts into the same directory as R.exe and Rscript.exe (typically: C:\Program Files\R\R-3.5.1\bin, depending on version). 
+Now, using the text editor of your choice, save the following line of code in a text file called `session-info.R`: 
 
 ```{r echo=FALSE, engine='bash'}
 cat session-info.R


### PR DESCRIPTION
Included the required information for where to save R scripts for command-line programming.  Originally it simply said to save the files (without detailing where to save the files).  This took me quiet a while to figure this out while preparing for demonstration so I hope it helps others.