### PR TITLE
 make lesson suitable for teaching with locally-built (serverless) pages

### DIFF
--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Discussion
-permalink: /discuss/
 ---
 
 ## Error returned when attempting to calculate mean of data.frame rows

--- a/_extras/figures.md
+++ b/_extras/figures.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: Figures
-permalink: /figures/
 ---
 {% include all_figures.html %}

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: "Instructor Notes"
-permalink: /guide/
 ---
 
 This lesson is written as an introduction to R,
@@ -103,13 +101,13 @@ line and this should resolve the issue.
 *   Provide shortcut for the assignment operator (`<-`) (RStudio: <kbd>Alt</kbd>+<kbd>-</kbd> on
     Windows/Linux; <kbd>Option</kbd>+<kbd>-</kbd> on Mac).
 
-*   When performing operations on sliced rows of data frames, be aware that some 
-    functions in R automatically convert the object type to a numeric vector, while 
-    others do not. For example, `max(dat[1, ])` works as expected, while `mean(dat[1, ])` 
-    returns an error. You can fix this by including an explicit call to `as.numeric()`, 
-    for example `mean(as.numeric(dat[1, ]))`. This issue is also mentioned in a callout 
-    box in the lesson materials, since it is unexpected and can create confusion when 
-    simple examples fail (by contrast, operations on sliced columns of data frames always 
+*   When performing operations on sliced rows of data frames, be aware that some
+    functions in R automatically convert the object type to a numeric vector, while
+    others do not. For example, `max(dat[1, ])` works as expected, while `mean(dat[1, ])`
+    returns an error. You can fix this by including an explicit call to `as.numeric()`,
+    for example `mean(as.numeric(dat[1, ]))`. This issue is also mentioned in a callout
+    box in the lesson materials, since it is unexpected and can create confusion when
+    simple examples fail (by contrast, operations on sliced columns of data frames always
     work as expected, since columns of data frames are already vectors).
 
 ## [Addressing Data]({{ page.root }}/10-supp-addressing-data/)

--- a/reference.md
+++ b/reference.md
@@ -1,6 +1,5 @@
 ---
 layout: reference
-root: .
 ---
 
 ## Basic Operation

--- a/setup.md
+++ b/setup.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Setup
-root: .
 ---
 
 This lesson assumes you have current versions of the following installed on your computer:


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Software Carpentry Lessons page](https://software-carpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and adjusted internal links as part of this PR. If and when this is merged, I'll also make sure the link on https://software-carpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.