### PR TITLE
testing-and-documenting most useful tests (fixes #364)

### DIFF
--- a/_episodes_rmd/02-func-R.Rmd
+++ b/_episodes_rmd/02-func-R.Rmd
@@ -251,22 +251,13 @@ head(centered)
 It's hard to tell from the default output whether the result is correct, but there are a few simple tests that will reassure us:
 
 ```{r}
-# original min
-min(dat[, 4])
 # original mean
 mean(dat[, 4])
-# original max
-max(dat[, 4])
-# centered min
-min(centered)
 # centered mean
 mean(centered)
-# centered max
-max(centered)
 ```
 
-That seems almost right: the original mean was about `r round(mean(dat[, 4]), 2)`, so the lower bound from zero is now about `r -round(mean(dat[, 4]), 2)`.
-The mean of the centered data is `r mean(centered)`.
+That seems right: the original mean was about `r round(mean(dat[, 4]), 2)` and the mean of the centered data is `r mean(centered)`.
 We can even go further and check that the standard deviation hasn't changed:
 
 ```{r}


### PR DESCRIPTION
This resolves #364. I have remove tests which check for `min` and `max` values of a vector which has been centered around 0.
 
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
