### PR TITLE
Fix block quote formatting

### DIFF
--- a/_episodes_rmd/11-supp-read-write-csv.Rmd
+++ b/_episodes_rmd/11-supp-read-write-csv.Rmd
@@ -223,9 +223,9 @@ That's better!
 > > 
 > > ~~~
 > > read.csv(
-  file = 'data/car-speeds.csv',
-  na.strings = c("Black", "Blue")
-  )
+> >   file = 'data/car-speeds.csv',
+> >   na.strings = c("Black", "Blue")
+> > )
 > > ~~~
 > > {: .language-r}
 > {: .solution}


### PR DESCRIPTION
There was a gap in the block quote, which is find for Kramdown, but not so fine for commonmark or github's markdown parser (see the same section here: https://github.com/swcarpentry/r-novice-inflammation/blob/6108ab24cee6fece6671f97ed6b8f4cfe8552ded/_episodes/11-supp-read-write-csv.md).
