### PR TITLE
Fix for R Version 4.0

### DIFF
--- a/_episodes_rmd/11-supp-read-write-csv.Rmd
+++ b/_episodes_rmd/11-supp-read-write-csv.Rmd
@@ -21,17 +21,11 @@ source('../bin/chunk-options.R')
 knitr_fig_path("11-supp-read-write-csv-")
 ```
 
-The most common way that scientists store data is in Excel spreadsheets.
-While there are R packages designed to access data from Excel spreadsheets (e.g., gdata, RODBC, XLConnect, xlsx, RExcel),
-users often find it easier to save their spreadsheets in [comma-separated values]({{ page.root }}/reference.html#comma-separated-values-csv) files (CSV)
-and then use R's built in functionality to read and manipulate the data.
-In this short lesson, we'll learn how to read data from a .csv and write to a new .csv,
-and explore the [arguments]({{ page.root }}/reference.html#argument) that allow you read and write the data correctly for your needs.
-
+The most common way that scientists store data is in Excel spreadsheets. While there are R packages designed to access data from Excel spreadsheets (e.g., gdata, RODBC, XLConnect, xlsx, RExcel), users often find it easier to save their spreadsheets in [comma-separated values](%7B%7B%20page.root%20%7D%7D/reference.html#comma-separated-values-csv) files (CSV) and then use R's built in functionality to read and manipulate the data. In this short lesson, we'll learn how to read data from a .csv and write to a new .csv, and explore the [arguments](%7B%7B%20page.root%20%7D%7D/reference.html#argument) that allow you read and write the data correctly for your needs.
 
 ### Read a .csv and Explore the Arguments
 
-Let's start by opening a .csv file containing information on the speeds at which cars of different colors were clocked in 45 mph zones in the four-corners states (`CarSpeeds.csv`). We will use the built in `read.csv(...)` [function call]({{ page.root }}/reference.html#function-call), which reads the data in as a data frame, and assign the data frame to a variable (using `<-`) so that it is stored in R's memory. Then we will explore some of the basic arguments that can be supplied to the function.
+Let's start by opening a .csv file containing information on the speeds at which cars of different colors were clocked in 45 mph zones in the four-corners states (`CarSpeeds.csv`). We will use the built in `read.csv(...)` [function call](%7B%7B%20page.root%20%7D%7D/reference.html#function-call), which reads the data in as a data frame, and assign the data frame to a variable (using `<-`) so that it is stored in R's memory. Then we will explore some of the basic arguments that can be supplied to the function.
 
 ```{r setwd, eval=FALSE}
 # First, set your working directory (see episode 'Analyzing Patient Data' for more
@@ -47,12 +41,7 @@ head(carSpeeds)
 
 > ## Changing Delimiters
 >
-> The default delimiter of the `read.csv()` function is a comma, but you can
-> use other delimiters by supplying the 'sep' argument to the function
-> (e.g., typing `sep = ';'` allows a semi-colon separated file to be correctly
-> imported - see `?read.csv()` for more information on this and other options for
-> working with different file types).
-{: .callout}
+> The default delimiter of the `read.csv()` function is a comma, but you can use other delimiters by supplying the 'sep' argument to the function (e.g., typing `sep = ';'` allows a semi-colon separated file to be correctly imported - see `?read.csv()` for more information on this and other options for working with different file types). {: .callout}
 
 The call above will import the data, but we have not taken advantage of several handy arguments that can be helpful in loading the data in the format we want. Let's explore some of these arguments.
 
@@ -74,7 +63,7 @@ Clearly this is not the desired behavior for this data set, but it may be useful
 
 ### The `stringsAsFactors` Argument
 
-This is perhaps the most important argument in `read.csv()`, particularly if you are working with categorical data. This is because the default behavior of R is to convert character [string]({{ page.root }}/reference.html#string)s into factors, which may make it difficult to do such things as replace values. For example, let's say we find out that the data collector was color blind, and accidentally recorded green cars as being blue. In order to correct the data set, let's replace 'Blue' with 'Green' in the `$Color` column:
+In older versions of R (prior to 4.0) this was the most important argument in `read.csv()`, particularly if you were working with categorical data. This is because the default behavior of R was to convert character [string](%7B%7B%20page.root%20%7D%7D/reference.html#string)s into factors, which may make it difficult to do such things as replace values. It is important to be aware of this behavior which we will demonstrate. For example, let's say we find out that the data collector was color blind, and accidentally recorded green cars as being blue. In order to correct the data set, let's replace 'Blue' with 'Green' in the `$Color` column:
 
 ```{r stringsAsFactorsTRUE}
 # Here we will use R's `ifelse` function, in which we provide the test phrase,
@@ -83,21 +72,15 @@ This is perhaps the most important argument in `read.csv()`, particularly if you
 # using '<-'
 
 # First - reload the data with a header
-carSpeeds <- read.csv(file = 'data/car-speeds.csv')
+carSpeeds <- read.csv(file = 'data/car-speeds.csv', stringsAsFactors = TRUE)
 
 carSpeeds$Color <- ifelse(carSpeeds$Color == 'Blue', 'Green', carSpeeds$Color)
 carSpeeds$Color
 ```
 
-What happened?!? It looks like 'Blue' was replaced with 'Green', but every other
-color was turned into a number (as a character string, given the quote marks before
-and after). This is because the colors of the cars were loaded as factors, and the
-factor level was reported following replacement.
+What happened?!? It looks like 'Blue' was replaced with 'Green', but every other color was turned into a number (as a character string, given the quote marks before and after). This is because the colors of the cars were loaded as factors, and the factor level was reported following replacement.
 
-To see the internal structure, we can use another function, `str()`. In this case,
-the dataframe's internal structure includes the format of each column, which is what
-we are interested in. `str()` will be reviewed a little more in the lesson
-[Data Types and Structures]({{ page.root }}/13-supp-data-structures/).
+To see the internal structure, we can use another function, `str()`. In this case, the dataframe's internal structure includes the format of each column, which is what we are interested in. `str()` will be reviewed a little more in the lesson [Data Types and Structures](%7B%7B%20page.root%20%7D%7D/13-supp-data-structures/).
 
 ```{r}
 str(carSpeeds)
@@ -114,8 +97,7 @@ carSpeeds$Color <- ifelse(carSpeeds$Color == 'Blue', 'Green', carSpeeds$Color)
 carSpeeds$Color
 ```
 
-That's better! And we can see how the data now is read as character instead of factor.
-
+That's better! And we can see how the data now is read as character instead of factor. From R version 4.0 onwards this is the default behavior.
 
 ### The `as.is` Argument
 
@@ -137,28 +119,25 @@ carSpeeds$Color
 carSpeeds$State <- ifelse(carSpeeds$State == 'Arizona', 'Ohio', carSpeeds$State)
 carSpeeds$State
 ```
+
 We can see that `$Color` column is a character while `$State` is a factor.
 
 > ## Updating Values in a Factor
 >
-> Suppose we want to keep the colors of cars as factors for some other operations we want to perform.
-> Write code for replacing 'Blue' with 'Green' in the `$Color` column of the cars dataset
-> without importing the data with `stringsAsFactors=FALSE`.
+> Suppose we want to keep the colors of cars as factors for some other operations we want to perform. Write code for replacing 'Blue' with 'Green' in the `$Color` column of the cars dataset without importing the data with `stringsAsFactors=FALSE`.
 >
 > > ## Solution
-> > ~~~
-> > carSpeeds <- read.csv(file = 'data/car-speeds.csv')
-> > # Replace 'Blue' with 'Green' in cars$Color without using the stringsAsFactors
-> > # or as.is arguments
-> > carSpeeds$Color <- ifelse(as.character(carSpeeds$Color) == 'Blue',
-> >                          'Green',
-> >                          as.character(carSpeeds$Color))
-> > # Convert colors back to factors
-> > carSpeeds$Color <- as.factor(carSpeeds$Color)
-> > ~~~
-> > {: .language-r}
-> {: .solution}
-{: .challenge}
+> >
+> >     carSpeeds <- read.csv(file = 'data/car-speeds.csv')
+> >     # Replace 'Blue' with 'Green' in cars$Color without using the stringsAsFactors
+> >     # or as.is arguments
+> >     carSpeeds$Color <- ifelse(as.character(carSpeeds$Color) == 'Blue',
+> >                              'Green',
+> >                              as.character(carSpeeds$Color))
+> >     # Convert colors back to factors
+> >     carSpeeds$Color <- as.factor(carSpeeds$Color)
+> >
+> > {: .language-r} {: .solution} {: .challenge}
 
 ```{r Challenge, include=FALSE}
 carSpeeds <- read.csv(file = 'data/car-speeds.csv')
@@ -176,7 +155,7 @@ carSpeeds$Color <- as.factor(carSpeeds$Color)
 
 ### The `strip.white` Argument
 
-It is not uncommon for mistakes to have been made when the data were recorded, for example a space (whitespace) may have been inserted before a data value. By default this whitespace will be kept in the R environment, such that '\ Red' will be recognized as a different value than 'Red'. In order to avoid this type of error, use the `strip.white` argument. Let's see how this works by checking for the unique values in the `$Color` column of our dataset:
+It is not uncommon for mistakes to have been made when the data were recorded, for example a space (whitespace) may have been inserted before a data value. By default this whitespace will be kept in the R environment, such that ' Red' will be recognized as a different value than 'Red'. In order to avoid this type of error, use the `strip.white` argument. Let's see how this works by checking for the unique values in the `$Color` column of our dataset:
 
 Here, the data recorder added a space before the color of the car in one of the cells:
 
@@ -204,36 +183,26 @@ That's better!
 
 > ## Specify Missing Data When Loading
 >
-> It is common for data sets to have missing values, or mistakes.
-> The convention for recording missing values often depends on the individual who collected the data and can be recorded as `n.a.`, `--`, or empty cells " ". 
-> R recognises the reserved character string `NA` as a missing value, but not some of the examples above.
-> Let's say the inflamation scale in the data set we used earlier `inflammation-01.csv` actually starts at `1` for no inflamation and the zero values (`0`) were a missed observation.
-> Looking at the `?read.csv` help page is there an argument we could use to ensure all zeros (`0`) are read in as `NA`?
-> Perhaps, in the `car-speeds.csv` data contains mistakes and the person measuring the car speeds could not accurately distinguish between "Black or "Blue" cars.
-> Is there a way to specify more than one 'string', such as "Black" and "Blue", to be replaced by `NA`
+> It is common for data sets to have missing values, or mistakes. The convention for recording missing values often depends on the individual who collected the data and can be recorded as `n.a.`, `--`, or empty cells " ". R recognises the reserved character string `NA` as a missing value, but not some of the examples above. Let's say the inflamation scale in the data set we used earlier `inflammation-01.csv` actually starts at `1` for no inflamation and the zero values (`0`) were a missed observation. Looking at the `?read.csv` help page is there an argument we could use to ensure all zeros (`0`) are read in as `NA`? Perhaps, in the `car-speeds.csv` data contains mistakes and the person measuring the car speeds could not accurately distinguish between "Black or "Blue" cars. Is there a way to specify more than one 'string', such as "Black" and "Blue", to be replaced by `NA`
 >
 > > ## Solution
-> > 
-> > ~~~
-> > read.csv(file = "data/inflammation-01.csv", na.strings = "0")
-> > ~~~
+> >
+> >     read.csv(file = "data/inflammation-01.csv", na.strings = "0")
+> >
 > > {: .language-r}
-> > 
+> >
 > > or , in `car-speeds.csv` use a character vector for multiple values.
-> > 
-> > ~~~
-> > read.csv(
-> >   file = 'data/car-speeds.csv',
-> >   na.strings = c("Black", "Blue")
-> > )
-> > ~~~
-> > {: .language-r}
-> {: .solution}
-{: .challenge}
+> >
+> >     read.csv(
+> >       file = 'data/car-speeds.csv',
+> >       na.strings = c("Black", "Blue")
+> >     )
+> >
+> > {: .language-r} {: .solution} {: .challenge}
 
 ### Write a New .csv and Explore the Arguments
 
-After altering our cars dataset by replacing 'Blue' with 'Green' in the `$Color` column, we now want to save the output. There are several arguments for the `write.csv(...)` [function call]({{ page.root }}/reference.html#function-call), a few of which are particularly important for how the data are exported.  Let's explore these now.
+After altering our cars dataset by replacing 'Blue' with 'Green' in the `$Color` column, we now want to save the output. There are several arguments for the `write.csv(...)` [function call](%7B%7B%20page.root%20%7D%7D/reference.html#function-call), a few of which are particularly important for how the data are exported. Let's explore these now.
 
 ```{r writeData}
 # Export the data. The write.csv() function requires a minimum of two
@@ -244,8 +213,7 @@ write.csv(carSpeeds, file = 'data/car-speeds-cleaned.csv')
 
 If you open the file, you'll see that it has header names, because the data had headers within R, but that there are numbers in the first column.
 
-<img src="../fig/01-supp-csv-with-row-nums.png" alt="csv written without row.names argument" />
-
+<img src="../fig/01-supp-csv-with-row-nums.png" alt="csv written without row.names argument"/>
 
 ### The `row.names` Argument
 
@@ -257,15 +225,11 @@ write.csv(carSpeeds, file = 'data/car-speeds-cleaned.csv', row.names = FALSE)
 
 Now we see:
 
-<img src="../fig/01-supp-csv-without-row-nums.png" alt="csv written with row.names argument" />
+<img src="../fig/01-supp-csv-without-row-nums.png" alt="csv written with row.names argument"/>
 
 > ## Setting Column Names
 >
-> There is also a `col.names` argument, which can be used to set the column
-> names for a data set without headers. If the data set already has headers
-> (e.g., we used the `headers = TRUE` argument when importing the data) then a
-> `col.names` argument will be ignored.
-{: .callout}
+> There is also a `col.names` argument, which can be used to set the column names for a data set without headers. If the data set already has headers (e.g., we used the `headers = TRUE` argument when importing the data) then a `col.names` argument will be ignored. {: .callout}
 
 ### The `na` Argument
 
@@ -292,6 +256,6 @@ write.csv(carSpeeds,
 
 And we see:
 
-<img src="../fig/01-supp-csv-with-special-NA.png" alt="csv written with -9999 as NA" />
+<img src="../fig/01-supp-csv-with-special-NA.png" alt="csv written with -9999 as NA"/>
 
 {% include links.md %}

--- a/_episodes_rmd/12-supp-factors.Rmd
+++ b/_episodes_rmd/12-supp-factors.Rmd
@@ -136,9 +136,9 @@ dat <- read.csv(file = 'data/sample.csv', stringsAsFactors = TRUE)
 
 > ## Default Behavior
 >
-> `stringsAsFactors = TRUE` is the default behavior for R.
-> We could leave this argument out.
-> It is included here for clarity.
+> `stringsAsFactors = TRUE` was the default behavior for R prior to version 4.0.
+> We are using it here to override the default behaviour for R version 4.0 
+> which is `stringsAsFactors = TRUE`.
 {: .callout}
 
 ```{r examine-example-data}


### PR DESCRIPTION
Fix for change in default behaviour from R V4.0 from `stringsAsFactors = TRUE` to `stringsAsFactors = FALSE`

The course currently does not run as expected for these two episodes as the code examples rely on the old behaviour. I have tweaked the code and course notes so that this makes sense for running the course under R version 4.0 or higher, which I assume would be used for running the course now. 