### PR TITLE
R version 4 fix for change in stringsAsFactors behaviour

### DIFF
--- a/_episodes_rmd/11-supp-read-write-csv.Rmd
+++ b/_episodes_rmd/11-supp-read-write-csv.Rmd
@@ -74,7 +74,7 @@ Clearly this is not the desired behavior for this data set, but it may be useful
 
 ### The `stringsAsFactors` Argument
 
-This is perhaps the most important argument in `read.csv()`, particularly if you are working with categorical data. This is because the default behavior of R is to convert character [string]({{ page.root }}/reference.html#string)s into factors, which may make it difficult to do such things as replace values. For example, let's say we find out that the data collector was color blind, and accidentally recorded green cars as being blue. In order to correct the data set, let's replace 'Blue' with 'Green' in the `$Color` column:
+In older versions of R (prior to 4.0) this was perhaps the most important argument in `read.csv()`, particularly if you were working with categorical data. This is because the default behavior of R was to convert character [string]({{ page.root }}/reference.html#string)s into factors, which may make it difficult to do such things as replace values. It is important to be aware of this behaviour, which we will demonstrate. For example, let's say we find out that the data collector was color blind, and accidentally recorded green cars as being blue. In order to correct the data set, let's replace 'Blue' with 'Green' in the `$Color` column:
 
 ```{r stringsAsFactorsTRUE}
 # Here we will use R's `ifelse` function, in which we provide the test phrase,
@@ -83,7 +83,7 @@ This is perhaps the most important argument in `read.csv()`, particularly if you
 # using '<-'
 
 # First - reload the data with a header
-carSpeeds <- read.csv(file = 'data/car-speeds.csv')
+carSpeeds <- read.csv(file = 'data/car-speeds.csv', stringsAsFactors = TRUE)
 
 carSpeeds$Color <- ifelse(carSpeeds$Color == 'Blue', 'Green', carSpeeds$Color)
 carSpeeds$Color
@@ -114,7 +114,7 @@ carSpeeds$Color <- ifelse(carSpeeds$Color == 'Blue', 'Green', carSpeeds$Color)
 carSpeeds$Color
 ```
 
-That's better! And we can see how the data now is read as character instead of factor.
+That's better! And we can see how the data now is read as character instead of factor. From R version 4.0 onwards we do not have to specify `stringsAsFactors=FALSE`, this is the default behavior. 
 
 
 ### The `as.is` Argument

--- a/_episodes_rmd/12-supp-factors.Rmd
+++ b/_episodes_rmd/12-supp-factors.Rmd
@@ -136,8 +136,8 @@ dat <- read.csv(file = 'data/sample.csv', stringsAsFactors = TRUE)
 
 > ## Default Behavior
 >
-> `stringsAsFactors = TRUE` is the default behavior for R.
-> We could leave this argument out.
+> `stringsAsFactors = TRUE` was the default behavior for R prior to version 4.0.
+> We are using it here to override the default behaviour for R version 4.0 which is `stringsAsFactors = TRUE`.
 > It is included here for clarity.
 {: .callout}
 

--- a/_episodes_rmd/12-supp-factors.Rmd
+++ b/_episodes_rmd/12-supp-factors.Rmd
@@ -137,7 +137,7 @@ dat <- read.csv(file = 'data/sample.csv', stringsAsFactors = TRUE)
 > ## Default Behavior
 >
 > `stringsAsFactors = TRUE` was the default behavior for R prior to version 4.0.
-> We are using it here to override the default behaviour for R version 4.0 which is `stringsAsFactors = TRUE`.
+> We are using it here to override the default behaviour for R version 4.0 which is `stringsAsFactors = FALSE`.
 > It is included here for clarity.
 {: .callout}
 


### PR DESCRIPTION
From R version 4.0 the default behaviour for loading csv files has changed. This has broken episodes 11 and 12 in the course. 

 `stringsAsFactors = TRUE` was the default behavior for R prior to version 4.0. From version 4.0 this has changed to  `stringsAsFactors = FALSE`.

This fix makes some code and text changes to fix episodes 11 and 12.