### PR TITLE
StringAsFactor is no longer TRUE by defaul

### DIFF
--- a/_episodes_rmd/12-supp-factors.Rmd
+++ b/_episodes_rmd/12-supp-factors.Rmd
@@ -21,6 +21,12 @@ source('../bin/chunk-options.R')
 knitr_fig_path("12-supp-factors-")
 ```
 
+<!--  We need to update the lesson in totality since StringAsFactors is no longer = TRUE in R by default.-->
+
+<!-- From the programming setup page, we categorically said, this lessons assumes you have current versions of R software. Therefore, current version of R Software default to  `stringsAsFactors = FALSE' -->
+
+
+
 Factors are used to represent categorical data. Factors can be ordered or
 unordered and are an important class for statistical analysis and for plotting.
 
@@ -126,6 +132,8 @@ f <- levels(f)[f]
 f <- as.numeric(f)
 ```
 
+
+
 ### Using Factors
 
 Lets load our example data to see the use of factors:
@@ -136,7 +144,11 @@ dat <- read.csv(file = 'data/sample.csv', stringsAsFactors = TRUE)
 
 > ## Default Behavior
 >
-> `stringsAsFactors = TRUE` is the default behavior for R.
+> `stringsAsFactors = FALSE` is the default behavior for R. 
+
+
+
+
 > We could leave this argument out.
 > It is included here for clarity.
 {: .callout}


### PR DESCRIPTION
We need to update the lesson 12 in totality since StringAsFactors is no longer = TRUE in R by default. [This was announced at the R Core meetings in Toulouse in 2019 ](https://developer.r-project.org/Blog/public/2020/02/16/stringsasfactors/).

Also, from the [setup page](https://swcarpentry.github.io/r-novice-inflammation/setup.html), the lesson categorically said, "This lesson assumes you have current versions of the following installed on your computer". Therefore, the current version of R Software default to  StringsAsfactors = FALSE. 

