### PR TITLE
add alt-text for LaTeX equation

### DIFF
--- a/_episodes_rmd/07-knitr-R.Rmd
+++ b/_episodes_rmd/07-knitr-R.Rmd
@@ -49,7 +49,7 @@ When you click on File -> New File, there is an option for "R Markdown...". Choo
 Markdown also supports LaTeX equation editing.
 We can display pretty equations by enclosing them in `$`,
 e.g., `$\alpha = \dfrac{1}{(1 - \beta)^2}$` renders as:
-[![][tex-eq]][tex-eq]
+[![Rendered LaTeX equation][tex-eq]][tex-eq]
 
 The top of the source (.Rmd) file has some header material in YAML format (enclosed by triple dashes).
 Some of this gets displayed in the output header, other of it provides formatting information to the conversion engine.


### PR DESCRIPTION
This contribution is part of the Core Team accessibility hackathon to add alt-text to images across our lessons. Please feel free to improve upon these suggestions as desired!

N.B. in the new template, we _will_ have math rendering :grin: 