### PR TITLE
remove redundant piece of code

### DIFF
--- a/_episodes_rmd/04-cond.Rmd
+++ b/_episodes_rmd/04-cond.Rmd
@@ -126,16 +126,6 @@ Only one or the other is ever executed:
 
 In the example above, the test `num > 100` returns the value `FALSE`, which is why the code inside the `if` block was skipped and the code inside the `else` statement was run instead.
 
-```{r}
-num > 100
-```
-
-And as you likely guessed, the opposite of `FALSE` is `TRUE`.
-
-```{r}
-num < 100
-```
-
 Conditional statements don't have to include an `else`.
 If there isn't one, R simply does nothing if the test is false:
 


### PR DESCRIPTION
in line 97:
```{r}
num <- 37
num > 100
```

As 37 is not greater than 100, this returns a `FALSE` object. And as you likely guessed, the opposite of `FALSE` is `TRUE`.

```{r}
num < 100
```

and in line 129 (removed)

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
checkout@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
