### PR TITLE
Fix typo in example for function documentation

### DIFF
--- a/_episodes_rmd/08-making-packages-R.Rmd
+++ b/_episodes_rmd/08-making-packages-R.Rmd
@@ -125,7 +125,7 @@ Place each function into a separate R script and add documentation like this:
 #' @return The temperature in Celsius.
 #' @export
 #' @examples
-#' fahrenheit_to_kelvin(32)
+#' fahrenheit_to_celsius(32)
 
 fahrenheit_to_celsius <- function(temp_F) {
   temp_C <- (temp_F - 32) * 5 / 9


### PR DESCRIPTION
Example in documentation for `farenheit_to_celsius()` mistakenly uses `farenheit_to_kelvin()` simple fix.

