### PR TITLE
Error in line 128 in Episode "Making Packages in R"

### DIFF
--- a/_episodes_rmd/08-making-packages-R.Rmd
+++ b/_episodes_rmd/08-making-packages-R.Rmd
@@ -125,7 +125,7 @@ Place each function into a separate R script and add documentation like this:
 #' @return The temperature in Celsius.
 #' @export
 #' @examples
-#' fahrenheit_to_kelvin(32)
+#' fahrenheit_to_celsius(32)
 
 fahrenheit_to_celsius <- function(temp_F) {
   temp_C <- (temp_F - 32) * 5 / 9


### PR DESCRIPTION
The name of the function is incorrect in the description, the conversion is fahrenheit_to_celsius  not to fahrenheit_to_kelvin

<details>
<summary><strong>Instructions</strong></summary>

Thanks for contributing! :heart:

If this contribution is for instructor training, please email the link to this contribution to
instructor.training@carpentries.org so we can record your progress. You've completed your contribution
step for instructor checkout by submitting this contribution!

Keep in mind that **lesson maintainers are volunteers** and it may take them some time to
respond to your contribution. Although not all contributions can be incorporated into the lesson
materials, we appreciate your time and effort to improve the curriculum. If you have any questions
about the lesson maintenance process or would like to volunteer your time as a contribution
reviewer, please contact The Carpentries Team at team@carpentries.org.

You may delete these instructions from your comment.

\- The Carpentries
</details>
