### PR TITLE
Remove not yet introduced stdin

### DIFF
--- a/_episodes_rmd/readings-usage.R
+++ b/_episodes_rmd/readings-usage.R
@@ -4,8 +4,6 @@ main <- function() {
   filenames <- args[-1]
   if (!(action %in% c("--min", "--mean", "--max"))) {
     usage()
-  } else if (length(filenames) == 0) {
-    process(file("stdin"), action)
   } else {
     for (f in filenames) {
       process(f, action)


### PR DESCRIPTION
In the episode this solution is shown **before** the handling of the standard input. It is confusing to have `file("stdin")` at this point.