### PR TITLE
Escape backslash for newline

### DIFF
--- a/_episodes_rmd/05-cmdline.Rmd
+++ b/_episodes_rmd/05-cmdline.Rmd
@@ -13,7 +13,7 @@ keypoints:
 - "Use `commandArgs(trailingOnly = TRUE)` to obtain a vector of the command-line arguments that a program was run with."
 - "Avoid silent failures."
 - "Use `file(\"stdin\")` to connect to a program's standard input."
-- "Use `cat(vec, sep = \"\n\")` to write the elements of `vec` to standard output, one per line."
+- "Use `cat(vec, sep = \"\\n\")` to write the elements of `vec` to standard output, one per line."
 source: Rmd
 ---
 


### PR DESCRIPTION
The newline character `\n` has to be escaped to be shown.