### PR TITLE
Text on ln35, ep07 rmd.

### DIFF
--- a/_episodes_rmd/07-knitr-R.Rmd
+++ b/_episodes_rmd/07-knitr-R.Rmd
@@ -32,7 +32,7 @@ To get started, install the `knitr` package.
 install.packages("knitr")
 ```
 
-When you click on File -> New File, there is an option for "R Markdown...". Choose this and accept the default options in the dialog box that follows (but note that you can also create presentations this way). Save the file and click on the "Knit HTML" button at the top of the script. Compare the output to the source.
+To create a new `knitr` document in RStudio, click on File -> New File, and then select "R Markdown..." from the dropdown list. Accept the default options in the dialog box that follows (but note the other document formats to choose from, including presentations). Save the file and click on the dropdown arrow next to the "Knit" button at the top of the script window. This will bring up another dropdown menu, this time with a number of options for controlling `knitr` output. Select the "Knit to HTML" option to create an HTML document based on the markdown file. Compare the output to the source.
 
 > ## Formatting Text in Markdown
 >


### PR DESCRIPTION
Hello Maintainers! As part of the instructor training checkout process, I've been reading carefully through the R lessons to see where any improvements could be made. Here's one from ln35 or episode 7 in the Programming with R lesson.

I think the previous text was slightly confusing because it gave instructions that would only make sense within RStudio without first specifying that they were meant to be followed in an RStudio session. There were also some awkward phrases that could lead to confusion even within an RStudio session, like "...click on the “Knit HTML” button at the top of the script...". In my Ubuntu version of RStudio, that option is in a dropdown menu accessible from the toolbar of the script window but it's not directly in the bar itself. The text could also lead people to look for a button inside the script rather than in the toolbar for the window containing the script. So, I've suggested some minor text edits with this PR. 