### PR TITLE
Replace link to R Packages book style chapter with one to the tidyverse style guide

### DIFF
--- a/_episodes_rmd/01-starting-with-data.Rmd
+++ b/_episodes_rmd/01-starting-with-data.Rmd
@@ -206,8 +206,8 @@ weight_kg
 > in R can be a valid part of a variable name; thus the above assignment could have easily been `weight.kg <- 57.5`.
 > This is often confusing to R newcomers who have programmed in languages where `.` has a more significant meaning.
 > Today, most R programmers 1) start variable names with lower case letters, 2) separate words in variable names with
-> underscores, and 3) use only lowercase letters, underscores, and numbers in variable names. The book *R Packages* includes
-> a [chapter](http://r-pkgs.had.co.nz/style.html) on this and other style considerations.
+> underscores, and 3) use only lowercase letters, underscores, and numbers in variable names. The *Tidyverse Style Guide* includes
+> a [section]([http://r-pkgs.had.co.nz/style.html](https://style.tidyverse.org/syntax.html)) on this and other style considerations.
 {: .callout}
 
 <img src="../fig/reassign-variables.svg" alt="Reassigning Variables" />

--- a/_episodes_rmd/01-starting-with-data.Rmd
+++ b/_episodes_rmd/01-starting-with-data.Rmd
@@ -207,7 +207,7 @@ weight_kg
 > This is often confusing to R newcomers who have programmed in languages where `.` has a more significant meaning.
 > Today, most R programmers 1) start variable names with lower case letters, 2) separate words in variable names with
 > underscores, and 3) use only lowercase letters, underscores, and numbers in variable names. The *Tidyverse Style Guide* includes
-> a [section]([http://r-pkgs.had.co.nz/style.html](https://style.tidyverse.org/syntax.html)) on this and other style considerations.
+> a [section](https://style.tidyverse.org/syntax.html) on this and other style considerations.
 {: .callout}
 
 <img src="../fig/reassign-variables.svg" alt="Reassigning Variables" />


### PR DESCRIPTION
Hey there! I noticed that the link in Episode 1 (Analyzing Patient Data) to the style chapter in the R Packages book was broken. 

The [2nd edition of R packages](https://r-pkgs.org/code.html#code-style) refers readers to the tidyverse style guide, so perhaps the lesson should instead bring the learner to the ["Object Names" section of style guide](https://style.tidyverse.org/syntax.html) instead.  