### PR TITLE
Fix missing links in episodes 06 and 07

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ community listed at <https://carpentries.org/connect/> including via social
 media, slack, newsletters, and email lists. You can also [reach us by
 email][contact].
 
-[repo]: https://example.com/FIXME
+[repo]: https://github.com/swcarpentry/r-novice-inflammation/
 [contact]: mailto:team@carpentries.org
 [cp-site]: https://carpentries.org/
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
@@ -111,7 +111,7 @@ email][contact].
 [github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
-[how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[how-contribute]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://carpentries.org/help-wanted-issues/
 [lc-issues]: https://github.com/issues?q=user%3ALibraryCarpentry
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry

--- a/episodes/06-best-practices-R.Rmd
+++ b/episodes/06-best-practices-R.Rmd
@@ -174,7 +174,12 @@ cat inflammation_fxns.R
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-
+[swc-lesson-git]: https://swcarpentry.github.io/git-novice/
+[rstudio-git]: https://web.archive.org/web/20190103191213/https://support.rstudio.com/hc/en-us/articles/200532077
+[rstudio-project]: https://posit.co/resources/videos/programming-part-1-writing-code-in-rstudio/
+[dc-rstudio]: https://datacarpentry.org/R-ecology-lesson/00-before-we-start.html#getting-set-up
+[sessionInfo]: https://stackoverflow.com/a/21967272/4341322
+[gh-pr]: https://github.com/skills/review-pull-requests
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 

--- a/episodes/07-knitr-R.Rmd
+++ b/episodes/07-knitr-R.Rmd
@@ -55,7 +55,7 @@ In the example document add
 Markdown also supports LaTeX equation editing.
 We can display pretty equations by enclosing them in `$`,
 e.g., `$\alpha = \dfrac{1}{(1 - \beta)^2}$` renders as:
-[![Rendered LaTeX equation][tex-eq]][tex-eq]
+$\alpha = \dfrac{1}{(1 - \beta)^2}$
 
 The top of the source (.Rmd) file has some header material in YAML format (enclosed by triple dashes).
 Some of this gets displayed in the output header, other of it provides formatting information to the conversion engine.
@@ -78,7 +78,7 @@ but you can also print the results of code within a text block by enclosing code
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
-
+[pandoc]: https://pandoc.org/
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 


### PR DESCRIPTION
Fixes missing links in episodes 06 and 07. Also fixes #580.

Most of the links are taken from [this version of `links.md`](https://github.com/swcarpentry/r-novice-inflammation/blob/1d3fada4497b240d597e867057141eb980f3b080/_includes/links.md) as that file has since been removed from this repo.

Extra changes:
* [gh-pr] changed from a dead link (archived version: https://web.archive.org/web/20200218072846/https://lab.github.com/githubtraining/reviewing-pull-requests) to https://github.com/skills/review-pull-requests
* [rstudio-project] changed from a redirected link (archived version: https://web.archive.org/web/20200429201748/https://resources.rstudio.com/wistia-rstudio-essentials-2/rstudioessentialsmanagingpart1-2) to https://posit.co/resources/videos/programming-part-1-writing-code-in-rstudio/
* [tex-eq] removed completely as we can format the LaTeX inline now!