### PR TITLE
Small fixes to formatting and readability

### DIFF
--- a/episodes/02-func-R.Rmd
+++ b/episodes/02-func-R.Rmd
@@ -236,10 +236,10 @@ mySum <- function(input_1, input_2 = 10) {
 ```
 
 1. Given the above code was run, which value does `mySum(input_1 = 1, 3)` produce?
-  1. 4
-  2. 11
-  3. 23
-  4. 30
+    1. 4
+    2. 11
+    3. 23
+    4. 30
 2. If `mySum(3)` returns 13, why does `mySum(input_2 = 3)` return an error?
 
 :::::::::::::::  solution

--- a/episodes/02-func-R.Rmd
+++ b/episodes/02-func-R.Rmd
@@ -236,17 +236,17 @@ mySum <- function(input_1, input_2 = 10) {
 ```
 
 1. Given the above code was run, which value does `mySum(input_1 = 1, 3)` produce?
-    1. 4
-    2. 11
-    3. 23
-    4. 30
+    a. 4
+    b. 11
+    c. 23
+    d. 30
 2. If `mySum(3)` returns 13, why does `mySum(input_2 = 3)` return an error?
 
 :::::::::::::::  solution
 
 ## Solution
 
-1. The solution is `1.`.
+1. The solution is `a.`.
 
 2. Read the error message: `argument "input_1" is missing, with no default`
   means that no value for `input_1` is provided in the function call,

--- a/episodes/06-best-practices-R.Rmd
+++ b/episodes/06-best-practices-R.Rmd
@@ -126,8 +126,7 @@ rather than:
 dat <- read.csv(file = "/Users/Karthik/Documents/sannic-project/files/dataset-2013-01.csv", header = TRUE)
 ```
 
-{:start="5"}
-5\. R can run into memory issues. It is a common problem to run out of memory after running R scripts for a long time. To inspect the objects in your current R environment, you can list the objects, search current packages, and remove objects that are currently not in use. A good practice when running long lines of computationally intensive code is to remove temporary objects after they have served their purpose. However, sometimes, R will not clean up unused memory for a while after you delete objects. You can force R to tidy up its memory by using `gc()`.
+5. R can run into memory issues. It is a common problem to run out of memory after running R scripts for a long time. To inspect the objects in your current R environment, you can list the objects, search current packages, and remove objects that are currently not in use. A good practice when running long lines of computationally intensive code is to remove temporary objects after they have served their purpose. However, sometimes, R will not clean up unused memory for a while after you delete objects. You can force R to tidy up its memory by using `gc()`.
 
 ```{r gc_ex, eval=FALSE}
 # Sample dataset of 1000 rows
@@ -141,8 +140,8 @@ ls() # Lists all the objects in your current workspace
 rm(list = ls()) # If you want to delete all the objects in the workspace and start with a clean slate
 ```
 
-{:start="6"}
-6\. [Don't save a session history][dc-rstudio] (the default option in R, when it asks if you want an `RData` file). Instead, start in a clean environment so that older objects don't remain in your environment any longer than they need to. If that happens, it can lead to unexpected results.
+
+6. [Don't save a session history][dc-rstudio] (the default option in R, when it asks if you want an `RData` file). Instead, start in a clean environment so that older objects don't remain in your environment any longer than they need to. If that happens, it can lead to unexpected results.
 
 7. Wherever possible, [keep track of `sessionInfo()` somewhere][sessionInfo] in your project folder. Session information is invaluable because it captures all of the packages used in the current project. If a newer version of a package changes the way a function behaves, you can always go back and reinstall the version that worked (Note: At least on CRAN, all older versions of packages are permanently archived).
 

--- a/episodes/12-supp-factors.Rmd
+++ b/episodes/12-supp-factors.Rmd
@@ -90,25 +90,25 @@ You have a vector representing levels of exercise undertaken by 5 subjects
 
 What is the best way to represent this in R?
 
-a) exercise \<- c("L", "N", "N", "I", "L")
+a. `exercise <- c("L", "N", "N", "I", "L")`
 
-b) exercise \<- factor(c("L", "N", "N", "I", "L"), ordered = TRUE)
+b. `exercise <- factor(c("L", "N", "N", "I", "L"), ordered = TRUE)`
 
-c) exercise \< -factor(c("L", "N", "N", "I", "L"), levels = c("N", "L", "I"), ordered = FALSE)
+c. `exercise < -factor(c("L", "N", "N", "I", "L"), levels = c("N", "L", "I"), ordered = FALSE)`
 
-d) exercise \<- factor(c("L", "N", "N", "I", "L"), levels = c("N", "L", "I"), ordered = TRUE)
+d. `exercise <- factor(c("L", "N", "N", "I", "L"), levels = c("N", "L", "I"), ordered = TRUE)`
 
 :::::::::::::::  solution
 
 ## Solution
 
-Correct solution is **d)**
+Correct solution is **d.**
 
 ```r
 exercise <- factor(c("L", "N", "N", "I", "L"), levels = c("N", "L", "I"), ordered = TRUE)
 ```
 
-We only expect three cathegories ("L", "N", "N", "I", "L").
+We only expect three categories ("N", "L", "I").
 We can order these from least intense to most intense, so let's use `ordered`.
 
 

--- a/episodes/12-supp-factors.Rmd
+++ b/episodes/12-supp-factors.Rmd
@@ -86,17 +86,17 @@ information built in. It is particularly helpful when there are many levels
 
 You have a vector representing levels of exercise undertaken by 5 subjects
 
-**"l", "n", "n", "i", "l"** ; n=none, l=light, i=intense
+**"L", "N", "N", "I", "L"** ; N=none, L=light, I=intense
 
 What is the best way to represent this in R?
 
-a) exercise \<- c("l", "n", "n", "i", "l")
+a) exercise \<- c("L", "N", "N", "I", "L")
 
-b) exercise \<- factor(c("l", "n", "n", "i", "l"), ordered = TRUE)
+b) exercise \<- factor(c("L", "N", "N", "I", "L"), ordered = TRUE)
 
-c) exercise \< -factor(c("l", "n", "n", "i", "l"), levels = c("n", "l", "i"), ordered = FALSE)
+c) exercise \< -factor(c("L", "N", "N", "I", "L"), levels = c("N", "L", "I"), ordered = FALSE)
 
-d) exercise \<- factor(c("l", "n", "n", "i", "l"), levels = c("n", "l", "i"), ordered = TRUE)
+d) exercise \<- factor(c("L", "N", "N", "I", "L"), levels = c("N", "L", "I"), ordered = TRUE)
 
 :::::::::::::::  solution
 
@@ -105,10 +105,10 @@ d) exercise \<- factor(c("l", "n", "n", "i", "l"), levels = c("n", "l", "i"), or
 Correct solution is **d)**
 
 ```r
-exercise <- factor(c("l", "n", "n", "i", "l"), levels = c("n", "l", "i"), ordered = TRUE)
+exercise <- factor(c("L", "N", "N", "I", "L"), levels = c("N", "L", "I"), ordered = TRUE)
 ```
 
-We only expect three cathegories ("n", "l", "i").
+We only expect three cathegories ("L", "N", "N", "I", "L").
 We can order these from least intense to most intense, so let's use `ordered`.
 
 

--- a/episodes/13-supp-data-structures.Rmd
+++ b/episodes/13-supp-data-structures.Rmd
@@ -420,10 +420,12 @@ length(x)
 
 ## Solution
 
-1. ```{r examine-lists-1}
+1. 
+  ```{r examine-lists-1}
   class(x[1])
   ```
-2. ```{r examine-lists-2}
+2.
+  ```{r examine-lists-2}
   class(x[[1]])
   ```
 
@@ -450,10 +452,12 @@ names(xlist)
 
 ## Solution
 
-1. ```{r examine-named-lists-1}
+1. 
+  ```{r examine-named-lists-1}
   length(xlist)
   ```
-2. ```{r examine-named-lists-2}
+2.
+  ```{r examine-named-lists-2}
   str(xlist)
   ```
 

--- a/episodes/13-supp-data-structures.Rmd
+++ b/episodes/13-supp-data-structures.Rmd
@@ -421,13 +421,13 @@ length(x)
 ## Solution
 
 1. 
-  ```{r examine-lists-1}
-  class(x[1])
-  ```
+    ```{r examine-lists-1}
+    class(x[1])
+    ```
 2.
-  ```{r examine-lists-2}
-  class(x[[1]])
-  ```
+    ```{r examine-lists-2}
+    class(x[[1]])
+    ```
 
 :::::::::::::::::::::::::
 


### PR DESCRIPTION
While working through the course, I noticed some formatting that hasn't transferred across quite right in the Workbench transition, and also a couple of places where readability could be improved. Here's a batch of suggested improvements.

Screenshots show current pages on the left, updated pages on the right.

1. Indented sublist by 4 spaces rather than 2, and changed labels for clarity
![Left: List with items labelled 1-6. Right: List with items 1 and 2, item 1 has sublist labelled a-d.](https://github.com/swcarpentry/r-novice-inflammation/assets/20683271/971b50d4-c7be-42da-8432-fac5d8a6e823)
2. Removed formatting to start list at item 5 (this is now done automatically just with the `5.`)
![Left: List starting at item 5 with {:start="5"} written in plain text at the front. Right: Correctly formatted list starting at item 5.](https://github.com/swcarpentry/r-novice-inflammation/assets/20683271/8b0a83fa-9ccb-4bdc-98cd-61d0115f80df)
3. I found the repeated lowercase "i" and "l" hard to tell apart in the "Representing Data in R" exercise, especially when surrounded with quotes, so I capitalised the letters in this exercise and solution and also added code formatting.
![Left: Exercise using a factor with levels lowercase n, i, l. Right: Same exercise with factor levels now capitalised N, I, L.](https://github.com/swcarpentry/r-novice-inflammation/assets/20683271/a02552a8-2804-4130-9e54-50490f5fd5fa)
4. Made code blocks within a list format correctly
![Left: List with verbatim text of R code blocks. Right: List with executed R code.](https://github.com/swcarpentry/r-novice-inflammation/assets/20683271/9f9afab1-02b6-4677-8c91-3aa352197390)