### PR TITLE
Add exercise timing to all episodes

### DIFF
--- a/episodes/01-starting-with-data.Rmd
+++ b/episodes/01-starting-with-data.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Analyzing Patient Data
 teaching: 45
-exercises: 0
+exercises: 10
 source: Rmd
 ---
 

--- a/episodes/02-func-R.Rmd
+++ b/episodes/02-func-R.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Creating Functions
 teaching: 30
-exercises: 0
+exercises: 10
 source: Rmd
 ---
 

--- a/episodes/03-loops-R.Rmd
+++ b/episodes/03-loops-R.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Analyzing Multiple Data Sets
 teaching: 30
-exercises: 0
+exercises: 10
 source: Rmd
 ---
 

--- a/episodes/04-cond.Rmd
+++ b/episodes/04-cond.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Making Choices
 teaching: 30
-exercises: 0
+exercises: 10
 source: Rmd
 ---
 

--- a/episodes/05-cmdline.Rmd
+++ b/episodes/05-cmdline.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Command-Line Programs
 teaching: 30
-exercises: 0
+exercises: 50
 source: Rmd
 ---
 

--- a/episodes/06-best-practices-R.Rmd
+++ b/episodes/06-best-practices-R.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Best Practices for Writing R Code
 teaching: 10
-exercises: 0
+exercises: 5
 source: Rmd
 ---
 

--- a/episodes/07-knitr-R.Rmd
+++ b/episodes/07-knitr-R.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Dynamic Reports with knitr
 teaching: 20
-exercises: 0
+exercises: 5
 source: Rmd
 ---
 

--- a/episodes/08-making-packages-R.Rmd
+++ b/episodes/08-making-packages-R.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Making Packages in R
 teaching: 30
-exercises: 0
+exercises: 5
 source: Rmd
 ---
 

--- a/episodes/10-supp-addressing-data.Rmd
+++ b/episodes/10-supp-addressing-data.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Addressing Data
 teaching: 20
-exercises: 0
+exercises: 10
 source: Rmd
 ---
 

--- a/episodes/11-supp-read-write-csv.Rmd
+++ b/episodes/11-supp-read-write-csv.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Reading and Writing CSV Files
 teaching: 30
-exercises: 0
+exercises: 5
 source: Rmd
 ---
 

--- a/episodes/12-supp-factors.Rmd
+++ b/episodes/12-supp-factors.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Understanding Factors
 teaching: 20
-exercises: 0
+exercises: 5
 source: Rmd
 ---
 

--- a/episodes/13-supp-data-structures.Rmd
+++ b/episodes/13-supp-data-structures.Rmd
@@ -1,7 +1,7 @@
 ---
 title: Data Types and Structures
 teaching: 45
-exercises: 0
+exercises: 10
 source: Rmd
 ---
 

--- a/episodes/14-supp-call-stack.Rmd
+++ b/episodes/14-supp-call-stack.Rmd
@@ -1,7 +1,7 @@
 ---
 title: The Call Stack
 teaching: 15
-exercises: 0
+exercises: 5
 source: Rmd
 ---
 


### PR DESCRIPTION
Fix #519

Total time for the entire lesson is now 4h45min without the supplementary episodes and 8h15min with the supplementary episodes.

![Screenshot of the timings table from https://swcarpentry.github.io/r-novice-inflammation/instructor/index.html](https://github.com/swcarpentry/r-novice-inflammation/assets/10783929/a897f496-7607-4005-96d3-2d5a6685e7b1)

Should we reach out on the instructor channel to double check this is in line with the experience of people who have recently taught this lesson?

