### PR TITLE
Remove hardcoded div titles

### DIFF
--- a/episodes/01-starting-with-data.Rmd
+++ b/episodes/01-starting-with-data.Rmd
@@ -117,16 +117,12 @@ read.csv(file = "data/inflammation-01.csv")
 
 :::::::::::::::  solution
 
-## Solution
-
 R will construct column headers from values in your first row of data,
 resulting in `X0 X0.1 X1 X3 X1.1 X2 ...`.
 
 Note that the character `X` is prepended: a standalone number would not be a valid variable
 name. Because column headers are variables, the same naming rules apply.
 Appending `.1`, `.2` etc. is necessary to avoid duplicate column headers.
-
-
 
 :::::::::::::::::::::::::
 
@@ -141,8 +137,6 @@ Also, different devices or software can generate data with different kinds of de
 Take a look at `?read.csv` and write the code to load a file called `commadec.txt` that has numeric values with commas as decimal mark, separated by semicolons.
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 read.csv(file = "data/commadec.txt", sep = ";", dec = ",")
@@ -302,8 +296,6 @@ age <- age - 20
 ```
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 mass <- 47.5
@@ -566,8 +558,6 @@ animal[4:6]
 
 :::::::::::::::  solution
 
-## Solutions
-
 1. `animal[4:1]`
 
 2. `"o" "n" "k" "e" "y"` and `"m" "o" "n" "e" "y"`, which means that a
@@ -596,8 +586,6 @@ Which of the following lines of R code gives the correct answer?
 
 :::::::::::::::  solution
 
-## Solution
-
 Answer: 3
 
 Explanation: You want to extract the part of the dataframe representing data for patient 5 from days three to seven. In this dataframe, patient data is organised in rows and the days are represented by the columns. Subscripting in R follows the `[i, j]` principle, where `i = rows` and `j = columns`. Thus, answer 3 is correct since the patient is represented by the value for i (5) and the days are represented by the values in j, which is a subset spanning day 3 to 7.
@@ -618,8 +606,6 @@ Let's pretend there was something wrong with the instrument on the first five da
 3. Print out the corrected data frame to check that your code has fixed the problem
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 whichPatients <- seq(2, 60, 2) # i.e., which rows
@@ -654,8 +640,6 @@ Think about the number of rows and columns you would expect as the result before
 apply call and check your intuition by applying the mean function.
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 # 1.
@@ -708,8 +692,6 @@ Create a plot showing the standard deviation of the inflammation data for each d
 
 :::::::::::::::  solution
 
-## Solution
-
 ```r
 sd_day_inflammation <- apply(dat, 2, sd)
 plot(sd_day_inflammation)
@@ -718,8 +700,6 @@ plot(sd_day_inflammation)
 :::::::::::::::::::::::::
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
-
-
 
 :::::::::::::::::::::::::::::::::::::::: keypoints
 
@@ -735,5 +715,3 @@ plot(sd_day_inflammation)
 - Use `plot` to create simple visualizations.
 
 ::::::::::::::::::::::::::::::::::::::::::::::::::
-
-

--- a/episodes/02-func-R.Rmd
+++ b/episodes/02-func-R.Rmd
@@ -161,8 +161,6 @@ highlight(best_practice, asterisk)
 
 :::::::::::::::  solution
 
-## Solution
-
 ```r
 highlight <- function(content, wrapper) {
   answer <- c(wrapper, content, wrapper)
@@ -187,8 +185,6 @@ edges(dry_principle)
 ```
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 edges <- function(v) {
@@ -240,8 +236,6 @@ mySum <- function(input_1, input_2 = 10) {
 2. If `mySum(3)` returns 13, why does `mySum(input_2 = 3)` return an error?
 
 :::::::::::::::  solution
-
-## Solution
 
 1. The solution is `a.`.
 
@@ -428,8 +422,6 @@ Be sure to document your function with comments.
 
 :::::::::::::::  solution
 
-## Solution
-
 ```r
 analyze <- function(filename) {
   # Plots the average, min, and max inflammation over time.
@@ -459,8 +451,6 @@ Be sure to document your function with comments.
 Test that your `rescale` function is working properly using `min`, `max`, and `plot`.
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 rescale <- function(v) {
@@ -607,8 +597,6 @@ Do your two implementations produce the same results when
 both are given the same input vector and parameters?
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 rescale <- function(v, lower = 0, upper = 1) {

--- a/episodes/03-loops-R.Rmd
+++ b/episodes/03-loops-R.Rmd
@@ -188,8 +188,6 @@ print_N(3)
 
 :::::::::::::::  solution
 
-## Solution
-
 ```r
 print_N <- function(N) {
   nseq <- seq(N)
@@ -225,8 +223,6 @@ total(ex_vec)
 ```
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 total <- function(vec) {
@@ -267,8 +263,6 @@ expo(2, 4)
 ```
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 expo <- function(base, power) {
@@ -373,8 +367,6 @@ a filename pattern as its arguments
 and runs `analyze` for each file whose name matches the pattern.
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 analyze_all <- function(folder = "data", pattern) {

--- a/episodes/04-cond.Rmd
+++ b/episodes/04-cond.Rmd
@@ -252,8 +252,6 @@ plot_dist(dat[1:5, 10], threshold = 10)  # samples (rows) 1-5 on day (column) 10
 
 :::::::::::::::  solution
 
-## Solution
-
 ```r
 plot_dist <- function(x, threshold) {
   if (length(x) > threshold) {
@@ -301,8 +299,6 @@ plot_dist(dat[1:5, 10], threshold = 10)                    # samples (rows) 1-5 
 ```
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 plot_dist <- function(x, threshold, use_boxplot = TRUE) {
@@ -353,8 +349,6 @@ print(average_inf_max)
 ```
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 # Add your code here ...
@@ -489,8 +483,6 @@ Find the relevant argument to `plot` by reading the documentation (`?plot`),
 update `analyze`, and then recreate all the figures with `analyze_all`.
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 analyze <- function(filename, output = NULL) {

--- a/episodes/05-cmdline.Rmd
+++ b/episodes/05-cmdline.Rmd
@@ -186,8 +186,6 @@ Rscript arith.R 3 - 4
 
 :::::::::::::::  solution
 
-## Solution
-
 ```{r, engine="bash"}
 cat arith.R
 ```
@@ -197,8 +195,6 @@ cat arith.R
 2. What goes wrong if you try to add multiplication using `*` to the program?
 
 :::::::::::::::  solution
-
-## Solution
 
 An error message is returned due to "invalid input."
 This is likely because '\*' has a special meaning in the shell, as a wildcard.
@@ -216,8 +212,6 @@ Rscript find-pattern.R print-args
 ```
 
 :::::::::::::::  solution
-
-## Solution
 
 ```{r, engine="bash"}
 cat find-pattern.R
@@ -280,8 +274,6 @@ What is the best way to test your program?
 
 :::::::::::::::  solution
 
-## Solution
-
 ```{r, engine="bash"}
 cat check.R
 ```
@@ -342,8 +334,6 @@ Is the program easier to understand?
 Separately, modify the program so that if no action is specified (or an incorrect action is given), it prints a message explaining how it should be used.
 
 :::::::::::::::  solution
-
-## Solution
 
 ```{r, engine="bash"}
 cat readings-short.R
@@ -418,8 +408,6 @@ Write a program called `line-count.R` that works like the Unix `wc` command:
 - If one or more filenames are given, it reports the number of lines in each, followed by the total number of lines.
 
 :::::::::::::::  solution
-
-## Solution
 
 ```{r, engine="bash"}
 cat line-count.R

--- a/episodes/06-best-practices-R.Rmd
+++ b/episodes/06-best-practices-R.Rmd
@@ -156,8 +156,6 @@ rm(list = ls()) # If you want to delete all the objects in the workspace and sta
 
 :::::::::::::::  solution
 
-## Solution
-
 ```{r, engine="bash"}
 cat inflammation.R
 ```

--- a/episodes/10-supp-addressing-data.Rmd
+++ b/episodes/10-supp-addressing-data.Rmd
@@ -78,8 +78,6 @@ Think about the number of rows and columns you would expect as the result.
 
 :::::::::::::::  solution
 
-## Solution
-
 ```{r select-values}
 dat[1, 1]
 ```
@@ -97,8 +95,6 @@ If we leave out a dimension R will interpret this as a request for all values in
 What will be returned by `dat[, 2]`?
 
 :::::::::::::::  solution
-
-## Solution
 
 ```{r select-values-2}
 dat[, 2]
@@ -125,8 +121,6 @@ This can be very useful for addressing data.
 Use the colon operator to index just the aneurism count data (columns 6 to 9).
 
 :::::::::::::::  solution
-
-## Solution
 
 ```{r subset-sequence}
 dat[, 6:9]
@@ -291,8 +285,6 @@ plot(dat[dat$Group == 'Control', ]$BloodPressure)
 
 :::::::::::::::  solution
 
-## Solution
-
 1. The code for such a plot:
   ```{r plot-logical}
   plot(dat[dat$Group != 'Control', ]$BloodPressure)
@@ -300,8 +292,6 @@ plot(dat[dat$Group == 'Control', ]$BloodPressure)
 2. In addition to
   `dat$Group != 'Control'`, one could use
   `dat$Group %in% c("Treatment1", "Treatment2")`.
-  
-  
 
 :::::::::::::::::::::::::
 
@@ -325,8 +315,6 @@ In this dataset, values for Gender have been recorded as both uppercase `M, F` a
 Combine the addressing and assignment operations to convert all values to lowercase.
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 dat[dat$Gender == 'M', ]$Gender <- 'm'

--- a/episodes/11-supp-read-write-csv.Rmd
+++ b/episodes/11-supp-read-write-csv.Rmd
@@ -147,8 +147,6 @@ without importing the data with `stringsAsFactors=FALSE`.
 
 :::::::::::::::  solution
 
-## Solution
-
 ```r
 carSpeeds <- read.csv(file = 'data/car-speeds.csv')
 # Replace 'Blue' with 'Green' in cars$Color without using the stringsAsFactors
@@ -219,8 +217,6 @@ Perhaps, in the `car-speeds.csv` data contains mistakes and the person measuring
 Is there a way to specify more than one 'string', such as "Black" and "Blue", to be replaced by `NA`
 
 :::::::::::::::  solution
-
-## Solution
 
 ```r
 read.csv(file = "data/inflammation-01.csv", na.strings = "0")

--- a/episodes/12-supp-factors.Rmd
+++ b/episodes/12-supp-factors.Rmd
@@ -97,8 +97,6 @@ d. `exercise <- factor(c("L", "N", "N", "I", "L"), levels = c("N", "L", "I"), or
 
 :::::::::::::::  solution
 
-## Solution
-
 Correct solution is **d.**
 
 ```r
@@ -107,8 +105,6 @@ exercise <- factor(c("L", "N", "N", "I", "L"), levels = c("N", "L", "I"), ordere
 
 We only expect three categories ("N", "L", "I").
 We can order these from least intense to most intense, so let's use `ordered`.
-
-
 
 :::::::::::::::::::::::::
 
@@ -194,8 +190,6 @@ Use the `factor()` command to modify the column `dat$Group` so that the *control
 
 :::::::::::::::  solution
 
-## Solution
-
 ```{r reordering-factors-2, fig.alt="Bar chart showing control and treatment to emphasise how the function factor() moves the control group to the last coulumn."}
 dat$Group <- factor(dat$Group, levels = c("Treatment1", "Treatment2", "Control"))
 barplot(table(dat$Group))
@@ -234,11 +228,7 @@ Why does this plot show 4 levels?
 
 :::::::::::::::  solution
 
-## Solution
-
 `dat$Gender` has 4 levels, so the plot shows 4 levels.
-
-
 
 :::::::::::::::::::::::::
 

--- a/episodes/12-supp-factors.Rmd
+++ b/episodes/12-supp-factors.Rmd
@@ -224,7 +224,11 @@ plot(x = dat$Gender, y = dat$BloodPressure)
 
 Why does this plot show 4 levels?
 
-*Hint* how many levels does `dat$Gender` have?
+::::::::::::::: hint
+
+How many levels does `dat$Gender` have?
+
+::::::::::::::::::::
 
 :::::::::::::::  solution
 

--- a/episodes/13-supp-data-structures.Rmd
+++ b/episodes/13-supp-data-structures.Rmd
@@ -243,11 +243,7 @@ Do you see a property that's common to all these vectors above?
 
 :::::::::::::::  solution
 
-## Solution
-
 All vectors are one-dimensional and each element is of the same type.
-
-
 
 :::::::::::::::::::::::::
 
@@ -316,8 +312,6 @@ running this code?
 *Hint* Can matrices be composed of elements of different data types?
 
 :::::::::::::::  solution
-
-## Solution
 
 We know that `typeof(FOURS)` will also return `"double"` since matrices
 are made of elements of the same data type. Note that you could do
@@ -415,8 +409,6 @@ length(x)
 
 :::::::::::::::  solution
 
-## Solution
-
 1. 
     ```{r examine-lists-1}
     class(x[1])
@@ -446,8 +438,6 @@ names(xlist)
 2. What is its structure?
 
 :::::::::::::::  solution
-
-## Solution
 
 1. 
   ```{r examine-named-lists-1}
@@ -567,8 +557,6 @@ Knowing that data frames are lists, can columns be of different type?
 What type of structure do you expect to see when you explore the structure of the `PlantGrowth` data frame? Hint: Use `str()`.
 
 :::::::::::::::  solution
-
-## Solution
 
 The weight column is numeric
 while group is a factor.

--- a/index.md
+++ b/index.md
@@ -46,13 +46,8 @@ To do all that, we'll have to learn a little bit about programming.
 
 ::::::::::::::::::::::::::::::::::::::::::  prereq
 
-## Prerequisites
-
 Learners need to understand the concepts of files and directories
 (including the working directory).
 We often use RStudio to teach this lesson, but it is not required.
 
-
 ::::::::::::::::::::::::::::::::::::::::::::::::::
-
-


### PR DESCRIPTION
We don't need to hardcode the div titles as sandpaper will add them on its own.

Hardcoding them also make it more difficult to centrally make updates from sandpaper (e.g., translations). At the moment for examples, the div titled "solutions" or "pre-requisites" (note the extra "s") can be translated by sandpaper.