### PR TITLE
Visualize pkg structure as tree

### DIFF
--- a/episodes/08-making-packages-R.Rmd
+++ b/episodes/08-making-packages-R.Rmd
@@ -43,7 +43,7 @@ package_name/
 ### DESCRIPTION file
 
 ```source
-Package: Package name
+Package: package_name
 Title: Brief package description
 Description: Longer package description
 Version: Version number(major.minor.patch)

--- a/episodes/08-making-packages-R.Rmd
+++ b/episodes/08-making-packages-R.Rmd
@@ -27,12 +27,16 @@ Why should you make your own R packages?
 An R package is the **basic unit of reusable code**.
 If you want to reuse code later or want others to be able to use your code, you should put it in a package.
 
-An R package requires four components:
+An R package requires four components, visualized in the folder tree below:
 
-- a DESCRIPTION file with metadata about the package
-- an R directory with the code
-- a man directory with documentation (we will create this automatically)
-- a NAMESPACE file listing user-level functions in the package (we will also create this automatically)
+```
+package_name/
+├── DESCRIPTION              # metadata about the package
+├── man/                     # function documentation (can be generated automatically)
+├── NAMESPACE                # list of user-level functions in the package (can be generated automatically)
+├── R/                       # R source code
+└── <other_components>
+```
 
 *There are other optional components. [rOpenSci community][r-open-sci] has written a science-focused guidebook for package development, while [the "R packages" book][r-pkgs-desc] contains all the fundamental information.*
 


### PR DESCRIPTION
Fix #586.

I also edited the package name in `DESCRIPTION` because:

- it makes sense to re-use the exact same name as what we used above
- "Package name" is not a valid package name
