### PR TITLE
Ensure bash used in container script runs

### DIFF
--- a/.github/workflows/docker_pr_receive.yaml
+++ b/.github/workflows/docker_pr_receive.yaml
@@ -232,3 +232,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run pr-comment.yaml --field workflow_id=${{ github.run_id }}
+        shell: bash

--- a/.github/workflows/update-cache.yaml
+++ b/.github/workflows/update-cache.yaml
@@ -189,3 +189,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run docker_pr_receive.yaml --field pr_number=${{ steps.cpr.outputs.pull-request-number }}
+        shell: bash


### PR DESCRIPTION
This addresses the issue the inside the docker container, the default shell is `sh`, not `bash`, so the gh command fails.
