### PR TITLE
Move PR check trigger to outside container

### DIFF
--- a/.github/workflows/docker_pr_receive.yaml
+++ b/.github/workflows/docker_pr_receive.yaml
@@ -227,7 +227,13 @@ jobs:
         run: sandpaper::reset_site()
         shell: Rscript {0}
 
-      - name: "Trigger PR checks"
+  pr-checks:
+    name: "Trigger PR Checks"
+    needs: test-pr
+    runs-on: ubuntu-latest
+    if: ${{ needs.test-pr.outputs.is_valid == 'true' }}
+    steps:
+      - name: "Trigger PR Checks"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
The PR check trigger in docker_pr_receive was running inside the docker container so did not have access to `gh`. This step now runs as its own job after docker teardown.